### PR TITLE
prototype(kaisel): ergonomics

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -113,6 +113,26 @@
                 "--target=lib/main_media_cataloguer.dart",
                 "--device-id=8132DC0D-96BA-47F8-BADD-974E67D93671",
             ],
+        },
+        {
+            "name": "[MOBILE TERSE] example",
+            "cwd": "packages/kaisel/example",
+            "request": "launch",
+            "type": "dart",
+            "args": [
+                "--target=lib/main_terse.dart",
+                "--device-id=63D5D2F7-1483-4A33-997C-534B6C8C4871"
+            ],
+        },
+        {
+            "name": "[TERSE] example",
+            "cwd": "packages/kaisel/example",
+            "request": "launch",
+            "type": "dart",
+            "args": [
+                "--target=lib/main_terse.dart",
+                "--device-id=8132DC0D-96BA-47F8-BADD-974E67D93671",
+            ],
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository is a [pub workspace](https://dart.dev/tools/pub/workspaces) cont
 
 | Package | Description |
 | --- | --- |
-| [`packages/kaisel`](packages/kaisel) | The Flutter router — delegate, shells, modules, adaptive layouts, transitions. This is the package you depend on. Start with its [README](packages/kaisel/README.md). |
+| [`packages/kaisel`](packages/kaisel) | The Flutter router — `KaiselRouterConfig` for one-line `MaterialApp.router` setup, terse `context.*` navigation, shells, modules, adaptive layouts, transitions. This is the package you depend on. Start with its [README](packages/kaisel/README.md). |
 | [`packages/kaisel_core`](packages/kaisel_core) | Pure-Dart navigation core — sealed routes, the router, guards, and URL codecs. No Flutter dependency. Re-exported by `kaisel`. |
 | [`packages/kaisel_devtools`](packages/kaisel_devtools) | DevTools extension for live router inspection. *Scaffold — not yet implemented.* |
 | [`packages/kaisel_lint`](packages/kaisel_lint) | Custom lint rules, quick fixes, and assists for the router, built on the first-party `analysis_server_plugin` API. |

--- a/packages/kaisel/CHANGELOG.md
+++ b/packages/kaisel/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.14.0
+
+Navigation ergonomics — terser setup and call sites, and a single shell
+accessor. Additive except for the removed split shell accessors (pre-1.0, so no
+deprecation cycle).
+
+### Added
+
+- **`KaiselRouterConfig<R>`** — a `RouterConfig` that bundles the router,
+  delegate, and (when given a `codec:`) the URL parser + platform provider into
+  the single object `MaterialApp.router(routerConfig:)` expects. Hold it as a
+  top-level `final` for an app-lifetime router: no `StatefulWidget`, no manual
+  delegate or parser, no `dispose`. `config.router` exposes the bundled
+  `KaiselRouter<R>`. The explicit `KaiselRouterDelegate` + parser path is
+  unchanged.
+- **Terse `context.*` navigation** — `context.push` / `pop` / `replaceTop` /
+  `pushOrReplaceTop` / `set` / `run<T>` on `BuildContext`. Each resolves the
+  nearest router whose route type accepts the argument (a runtime walk up the
+  tree). The trade vs `context.router<R>().push(...)`: a wrong-family route
+  throws at runtime instead of failing to compile. `context.router<R>()` stays
+  as the typed escape hatch.
+- **`context.shell()` → `KaiselShellController`** — one accessor for either
+  shell flavour, exposing `switchTo`, `activeBranch`, `branchCount`, and
+  `current` (the active branch's navigator, so chrome can read the active stack
+  and pop it without holding a router reference).
+- **`KaiselBranchedShell.specs(...)` + `KaiselBranchSpec<R>`** — declare a
+  branched shell from per-branch `initial` + `builder` specs; the shell creates,
+  owns, and disposes one router per branch (each branch's stack still survives
+  tab switches), so you never construct a `KaiselRouter` or
+  `BranchedShellRouter`. `KaiselBranchSpec.adaptive(...)` for adaptive branches.
+  The explicit `KaiselBranchedShell(shell:, branches:)` form stays for when you
+  need to hold the branch routers.
+
+### Removed (breaking)
+
+- **`context.branchedShell()`, `context.shellRouter<R>()`,
+  `context.branchRouter<R>()`** and the **`BranchedShellScope` / `ShellScope`**
+  inherited widgets. Use `context.shell()` (and `context.shell().current`). The
+  pre-1.0 release skips a deprecation cycle.
+
 ## 0.13.1
 
 ### Added

--- a/packages/kaisel/CHANGELOG.md
+++ b/packages/kaisel/CHANGELOG.md
@@ -16,11 +16,11 @@ deprecation cycle).
   `KaiselRouter<R>`. The explicit `KaiselRouterDelegate` + parser path is
   unchanged.
 - **Terse `context.*` navigation** — `context.push` / `pop` / `replaceTop` /
-  `pushOrReplaceTop` / `set` / `run<T>` on `BuildContext`. Each resolves the
-  nearest router whose route type accepts the argument (a runtime walk up the
-  tree). The trade vs `context.router<R>().push(...)`: a wrong-family route
-  throws at runtime instead of failing to compile. `context.router<R>()` stays
-  as the typed escape hatch.
+  `pushOrReplaceTop` / `set` / `run<T>` on `BuildContext`, a deliberate
+  convenience over the typed `context.router<R>().<verb>` (which stays the
+  idiomatic default). Each resolves the nearest router whose route type accepts
+  the argument (a runtime walk up the tree); the trade is that a wrong-family
+  route throws at runtime instead of failing to compile.
 - **`context.shell()` → `KaiselShellController`** — one accessor for either
   shell flavour, exposing `switchTo`, `activeBranch`, `branchCount`, and
   `current` (the active branch's navigator, so chrome can read the active stack

--- a/packages/kaisel/CHANGELOG.md
+++ b/packages/kaisel/CHANGELOG.md
@@ -32,6 +32,11 @@ deprecation cycle).
   `BranchedShellRouter`. `KaiselBranchSpec.adaptive(...)` for adaptive branches.
   The explicit `KaiselBranchedShell(shell:, branches:)` form stays for when you
   need to hold the branch routers.
+- **`KaiselBranchedShell.branchContentBuilder`** — optional override for how the
+  branches are laid out. Defaults to an `IndexedStack` (all branches mounted,
+  state preserved); pass one to use a `PageView` or any other container while
+  keeping the shell's back-button routing, scopes, and URL wiring. When you
+  override it, preserving per-branch state is yours to handle.
 
 ### Removed (breaking)
 

--- a/packages/kaisel/README.md
+++ b/packages/kaisel/README.md
@@ -153,7 +153,7 @@ builder: (context, route) => switch (route) {
 },
 ```
 
-Inside a branch screen, `context.router<TabRoute>()` returns the active branch's router and `context.shellRouter<TabRoute>()` returns the shell aggregator. (When tabs need *different* route types, reach for `KaiselBranchedShell` below instead.)
+Inside a branch screen, `context.router<TabRoute>()` returns the active branch's router and `context.shell()` returns the shell controller (`switchTo`, `activeBranch`, `current`). (When tabs need *different* route types, reach for `KaiselBranchedShell` below instead.)
 
 **`KaiselBranchedShell`** — each branch has its own sealed type. Pushing a route from the wrong tab is a compile error.
 
@@ -206,12 +206,12 @@ Inside a Home branch screen:
 ```dart
 context.router<HomeRoute>().push(const ProductDetail('42'));  // typed
 context.router<AppRoute>().push(const Settings());            // main router
-context.branchedShell().switchTo(2);                          // change tab
+context.shell().switchTo(2);                                 // change tab
 ```
 
 `RouterScope` lookup is by exact generic type, so `context.router<HomeRoute>()` and `context.router<AppRoute>()` don't collide. Each branch keeps its own back stack (via `IndexedStack`); Android back unwinds the active branch first, falling through to the parent router only at branch root.
 
-> **Inside the `chromeBuilder`, `context.router<BranchRoute>()` does not resolve** — each branch's `RouterScope` is installed *below* the chrome, and lookups only walk up. Use the `activeBranch`/`switchBranch` arguments or `context.branchedShell()` to drive the shell, and `context.router<AppRoute>()` for the root router. The typed branch router is only reachable from that branch's own screens.
+> **Inside the `chromeBuilder`, `context.router<BranchRoute>()` does not resolve** — each branch's `RouterScope` is installed *below* the chrome, and lookups only walk up. Use the `activeBranch`/`switchBranch` arguments or `context.shell()` to drive the shell, and `context.router<AppRoute>()` for the root router. The typed branch router is only reachable from that branch's own screens.
 
 ### 5. Modal flows with typed results
 

--- a/packages/kaisel/README.md
+++ b/packages/kaisel/README.md
@@ -45,9 +45,10 @@ Dart 3 has had the type machinery to do better since 2023: sealed classes, exhau
 ## Features
 
 - **Typed route stack** — `List<R>` over your sealed class. Pattern-matched page resolution with compile-time exhaustiveness.
+- **One-line setup, terse navigation** — `KaiselRouterConfig` collapses the router, delegate, and parser into a single `routerConfig:`; navigate with `context.push` / `pop` / `replaceTop` / `pushOrReplaceTop` / `set` / `run<T>`, with `context.router<R>()` as the typed escape hatch.
 - **Value equality for free** — default `props`-based `==`/`hashCode` on `KaiselRoute`. No manual equality, no codegen.
 - **Guard pipeline** — composable `FutureOr<List<R>> Function(current, proposed)` functions. Async-aware and pure-Dart testable.
-- **Shells** — `KaiselShell<R>` (homogeneous branches) and `KaiselBranchedShell` (per-branch typed routes), with per-tab back stacks, scoped state, and correct back-button handling.
+- **Shells** — `KaiselShell<R>` (homogeneous branches) and `KaiselBranchedShell` (per-branch typed routes; `.specs` declares branches without wiring routers), with per-tab back stacks, scoped state, and correct back-button handling. One `context.shell()` accessor drives either.
 - **Composable modules** — package a feature's routes, page builder, guards, and URL codec as a `const`-friendly `RouteModule`. Mount with `KaiselModuleMount<R>`; compose URLs with `ConfigCodecWithModules` without the host knowing the module's internal structure.
 - **URL-addressable** — deep-link into a branch stack (`/home/products/sku-42`) or a module stack (`/checkout/confirm`). Inactive branches keep in-memory state across tab switches.
 - **Modal flows with typed results** — `await router.run<T>(SomeFlow())` returns `Future<T?>`. Flows have their own sub-router and can nest, unwinding LIFO.
@@ -80,22 +81,24 @@ No-field variants get equality automatically (`Home() == Home()`). Variants with
 
 ### 2. Wire it up
 
+Bundle the router into a `KaiselRouterConfig` and hand it to `MaterialApp.router` — no `StatefulWidget`, no manual delegate or parser, no `dispose`:
+
 ```dart
-void main() {
-  final router = KaiselRouter<AppRoute>(initial: const Home());
-  runApp(MaterialApp.router(
-    routerDelegate: KaiselRouterDelegate<AppRoute>(
-      router: router,
-      builder: (context, route) => switch (route) {
-        Home() => const HomeScreen(),
-        ProductDetail(:final id) => ProductDetailScreen(id: id),
-      },
-    ),
-  ));
-}
+// Hold it as a top-level `final` for an app-lifetime router.
+final _config = KaiselRouterConfig<AppRoute>(
+  initial: const Home(),
+  builder: (context, route) => switch (route) {
+    Home() => const HomeScreen(),
+    ProductDetail(:final id) => ProductDetailScreen(id: id),
+  },
+);
+
+void main() => runApp(MaterialApp.router(routerConfig: _config));
 ```
 
 Add a variant and the switch fails to compile until you handle it. That's the entire point.
+
+`_config.router` is the underlying `KaiselRouter<AppRoute>` for imperative navigation outside the tree; pass `codec:` to make the app URL-addressable ([§6](#6-urls-optional)). For full control you can still construct the `KaiselRouterDelegate` and parser yourself — `KaiselRouterConfig` is the convenience layer over them.
 
 ### 3. Guards
 
@@ -170,24 +173,21 @@ final class ProductDetail extends HomeRoute {
 sealed class DiscoverRoute extends KaiselRoute { const DiscoverRoute(); }
 // ...
 
-// In your shell widget's state:
-final homeRouter = KaiselRouter<HomeRoute>(initial: const HomeRoot());
-final discoverRouter = KaiselRouter<DiscoverRoute>(initial: const DiscoverRoot());
-final shell = BranchedShellRouter(branches: [homeRouter, discoverRouter]);
-
-KaiselBranchedShell(
-  shell: shell,
+// Declare the branches — the shell creates, owns, and disposes one router per
+// branch. You never construct a KaiselRouter, and each branch's stack still
+// survives tab switches.
+KaiselBranchedShell.specs(
   branches: [
-    KaiselBranch<HomeRoute>(
-      router: homeRouter,
-      pageBuilder: (context, route) => switch (route) {
+    KaiselBranchSpec<HomeRoute>(
+      initial: const HomeRoot(),
+      builder: (context, route) => switch (route) {
         HomeRoot() => const HomeScreen(),
         ProductDetail(:final id) => ProductDetailScreen(id: id),
       },
     ),
-    KaiselBranch<DiscoverRoute>(
-      router: discoverRouter,
-      pageBuilder: (context, route) => switch (route) { /* ... */ },
+    KaiselBranchSpec<DiscoverRoute>(
+      initial: const DiscoverRoot(),
+      builder: (context, route) => switch (route) { /* ... */ },
     ),
   ],
   chromeBuilder: (context, active, branchContent, switchBranch) => Scaffold(
@@ -201,12 +201,17 @@ KaiselBranchedShell(
 )
 ```
 
+Use `KaiselBranchSpec.adaptive(...)` for an adaptive branch. When you need to hold the branch routers yourself, the explicit `KaiselBranchedShell(shell: BranchedShellRouter(...), branches: [KaiselBranch<R>(...)])` form stays.
+
 Inside a Home branch screen:
 
 ```dart
-context.router<HomeRoute>().push(const ProductDetail('42'));  // typed
-context.router<AppRoute>().push(const Settings());            // main router
-context.shell().switchTo(2);                                 // change tab
+context.push(const ProductDetail('42'));  // terse — nearest router that accepts it
+context.push(const Settings());           // resolves up to the main router
+context.shell().switchTo(2);              // change tab
+
+// Or the typed form, when you want the wrong-family check at compile time:
+context.router<HomeRoute>().push(const ProductDetail('42'));
 ```
 
 `RouterScope` lookup is by exact generic type, so `context.router<HomeRoute>()` and `context.router<AppRoute>()` don't collide. Each branch keeps its own back stack (via `IndexedStack`); Android back unwinds the active branch first, falling through to the parent router only at branch root.
@@ -292,6 +297,17 @@ routeInformationParser: KaiselRouteInformationParser<AppRoute>.fromStackCodec(
   codec: const AppStackCodec(),
   fallback: const [Home()],
 ),
+```
+
+With `KaiselRouterConfig` you skip the parser entirely — pass the codec as `codec:` (and an optional `fallback:`) and it wires the parser plus a `PlatformRouteInformationProvider` for you:
+
+```dart
+final _config = KaiselRouterConfig<AppRoute>(
+  initial: const Home(),
+  builder: _buildPage,
+  codec: StackToConfigCodec<AppRoute>(const AppStackCodec()),
+  fallback: const [Home()],
+);
 ```
 
 **`KaiselConfigCodec<R>`** — URLs that reach into a nested router (a `KaiselBranchedShell` or a `KaiselModuleMount`). The configuration carries the main stack plus an optional `nestedState`, a sealed `KaiselNestedConfig` that is either a `KaiselShellConfig` or a `KaiselModuleConfig`:

--- a/packages/kaisel/README.md
+++ b/packages/kaisel/README.md
@@ -45,7 +45,7 @@ Dart 3 has had the type machinery to do better since 2023: sealed classes, exhau
 ## Features
 
 - **Typed route stack** — `List<R>` over your sealed class. Pattern-matched page resolution with compile-time exhaustiveness.
-- **One-line setup, terse navigation** — `KaiselRouterConfig` collapses the router, delegate, and parser into a single `routerConfig:`; navigate with `context.push` / `pop` / `replaceTop` / `pushOrReplaceTop` / `set` / `run<T>`, with `context.router<R>()` as the typed escape hatch.
+- **One-line setup, typed navigation** — `KaiselRouterConfig` collapses the router, delegate, and parser into a single `routerConfig:`; navigate with the typed `context.router<R>().push` / `pop` / `replaceTop` / `pushOrReplaceTop` / `set` / `run<T>` (a wrong-family route is a compile error), or the terser `context.push(...)` when you'll take a runtime family check for the brevity.
 - **Value equality for free** — default `props`-based `==`/`hashCode` on `KaiselRoute`. No manual equality, no codegen.
 - **Guard pipeline** — composable `FutureOr<List<R>> Function(current, proposed)` functions. Async-aware and pure-Dart testable.
 - **Shells** — `KaiselShell<R>` (homogeneous branches) and `KaiselBranchedShell` (per-branch typed routes; `.specs` declares branches without wiring routers), with per-tab back stacks, scoped state, and correct back-button handling. One `context.shell()` accessor drives either.
@@ -206,12 +206,13 @@ Use `KaiselBranchSpec.adaptive(...)` for an adaptive branch. When you need to ho
 Inside a Home branch screen:
 
 ```dart
-context.push(const ProductDetail('42'));  // terse — nearest router that accepts it
-context.push(const Settings());           // resolves up to the main router
-context.shell().switchTo(2);              // change tab
+context.router<HomeRoute>().push(const ProductDetail('42'));  // compile-checked family
+context.router<AppRoute>().push(const Settings());            // the main router
+context.shell().switchTo(2);                                  // change tab
 
-// Or the typed form, when you want the wrong-family check at compile time:
-context.router<HomeRoute>().push(const ProductDetail('42'));
+// Or the terse convenience — resolves the nearest accepting router at runtime,
+// so a wrong-family route throws instead of failing to compile:
+context.push(const ProductDetail('42'));
 ```
 
 `RouterScope` lookup is by exact generic type, so `context.router<HomeRoute>()` and `context.router<AppRoute>()` don't collide. Each branch keeps its own back stack (via `IndexedStack`); Android back unwinds the active branch first, falling through to the parent router only at branch root.

--- a/packages/kaisel/README.md
+++ b/packages/kaisel/README.md
@@ -201,7 +201,7 @@ KaiselBranchedShell.specs(
 )
 ```
 
-Use `KaiselBranchSpec.adaptive(...)` for an adaptive branch. When you need to hold the branch routers yourself, the explicit `KaiselBranchedShell(shell: BranchedShellRouter(...), branches: [KaiselBranch<R>(...)])` form stays.
+Use `KaiselBranchSpec.adaptive(...)` for an adaptive branch. When you need to hold the branch routers yourself, the explicit `KaiselBranchedShell(shell: BranchedShellRouter(...), branches: [KaiselBranch<R>(...)])` form stays. Pass `branchContentBuilder` to swap the default `IndexedStack` for a `PageView` or any other layout (you then own per-branch state preservation).
 
 Inside a Home branch screen:
 

--- a/packages/kaisel/doc/migration/from-auto-route.md
+++ b/packages/kaisel/doc/migration/from-auto-route.md
@@ -33,12 +33,13 @@ part is testing that nothing regressed.
 | `@RoutePage()` annotation                   | `final class Home extends AppRoute`               |
 | Codegen-produced `HomeRoute()` class        | Hand-written class with `const` constructor       |
 | `@AutoRouterConfig` with `AutoRoute(...)`s  | A single `switch` expression in a page builder    |
+| `final _appRouter = AppRouter()` + `routerConfig:` | `final _config = KaiselRouterConfig<AppRoute>(...)` + `routerConfig:` |
 | `AutoRouteGuard.onNavigation()`             | Guard function `(current, proposed) → stack` in the pipeline |
-| `AutoTabsScaffold`                          | `KaiselBranchedShell` with N branches             |
+| `AutoTabsScaffold`                          | `KaiselBranchedShell.specs` with N branches       |
 | Parent route with `children: [...]`         | Stack entries; sub-routers if you need isolation  |
-| `context.router.push(HomeRoute())`          | `context.router<AppRoute>().push(const Home())`   |
-| `context.router.pop()`                      | `context.router<AppRoute>().pop()`                |
-| `context.router.replaceAll([HomeRoute()])`  | `context.router<AppRoute>().set([const Home()])`  |
+| `context.router.push(HomeRoute())`          | `context.push(const Home())`                      |
+| `context.router.pop()`                      | `context.pop()`                                   |
+| `context.router.replaceAll([HomeRoute()])`  | `context.set([const Home()])`                     |
 | `defaultRouteParser()`                      | A `KaiselConfigCodec<AppRoute>` you write         |
 | `build_runner` step in CI                   | (gone)                                            |
 
@@ -71,6 +72,54 @@ it but you'll no longer rebuild on every route change.
 
 Delete every `*.gr.dart` file. They'll be recreated as hand-written
 classes in step 2.
+
+Then replace the router instance. auto_route gives `MaterialApp.router`
+a `routerConfig:` (or `routerDelegate:` + `routeInformationParser:`)
+from a generated `AppRouter`. kaisel has the same slot: a top-level
+`final _config = KaiselRouterConfig<AppRoute>(...)`.
+
+**Before** (auto_route):
+
+```dart
+final _appRouter = AppRouter();
+
+class App extends StatelessWidget {
+  const App({super.key});
+  @override
+  Widget build(BuildContext context) =>
+      MaterialApp.router(routerConfig: _appRouter.config());
+}
+```
+
+**After** (kaisel):
+
+```dart
+final _config = KaiselRouterConfig<AppRoute>(
+  initial: const Home(),
+  builder: (context, route) => switch (route) {
+    Home() => const HomeScreen(),
+    ProductList() => const ProductListScreen(),
+    ProductDetail(:final id) => ProductDetailScreen(id: id),
+  },
+  // optional: guards:, pageWrapper:, modalBuilder:, codec:, fallback:
+);
+
+class App extends StatelessWidget {
+  const App({super.key});
+  @override
+  Widget build(BuildContext context) =>
+      MaterialApp.router(routerConfig: _config);
+}
+```
+
+`KaiselRouterConfig` is app-lifetime: a top-level `final`, no
+`StatefulWidget`, no manual `KaiselRouterDelegate`, no hand-rolled
+parser. Omit `codec:` and the app is URL-less; pass `codec:` (and
+optionally `fallback:`) to make it URL-addressable — it wires the
+parser and `PlatformRouteInformationProvider` for you (step 6).
+`_config.router` exposes the bundled `KaiselRouter` if you need
+imperative access. The explicit delegate-plus-parser form remains
+available as a lower tier.
 
 ### 2. Translate `@RoutePage` widgets to sealed routes
 
@@ -146,8 +195,8 @@ final class ProductDetail extends AppRoute {
 ### 3. Replace AutoRouterConfig with a page builder
 
 auto_route's route table — the giant list of `AutoRoute(page: ..., ...)`
-entries — becomes a single `switch` expression in the page builder
-on your `KaiselRouterDelegate`.
+entries — becomes a single `switch` expression in the `builder:` of
+your `KaiselRouterConfig` (the one from step 1).
 
 **Before** (auto_route):
 
@@ -166,9 +215,8 @@ class AppRouter extends $AppRouter {
 **After** (kaisel):
 
 ```dart
-final router = KaiselRouter<AppRoute>(initial: const Home());
-final delegate = KaiselRouterDelegate<AppRoute>(
-  router: router,
+final _config = KaiselRouterConfig<AppRoute>(
+  initial: const Home(),
   builder: (context, route) => switch (route) {
     Home() => const HomeScreen(),
     ProductList() => const ProductListScreen(),
@@ -219,9 +267,10 @@ List<AppRoute> authGuard(List<AppRoute> current, List<AppRoute> proposed) {
   return proposed;
 }
 
-// Registered once on the router, applies to all mutations:
-final router = KaiselRouter<AppRoute>(
+// Registered once on the config, applies to all mutations:
+final _config = KaiselRouterConfig<AppRoute>(
   initial: const Home(),
+  builder: (context, route) => switch (route) { /* ... */ },
   guards: [authGuard],
 );
 ```
@@ -239,8 +288,9 @@ For multiple cross-cutting concerns (auth + feature flags + entitlement
 checks), compose them as a list of guards rather than nesting:
 
 ```dart
-KaiselRouter<AppRoute>(
+KaiselRouterConfig<AppRoute>(
   initial: const Home(),
+  builder: (context, route) => switch (route) { /* ... */ },
   guards: [authGuard, featureFlagGuard, entitlementGuard],
 )
 ```
@@ -250,8 +300,8 @@ Each runs in order. Each receives the output of the previous.
 ### 5. Replace AutoTabsScaffold with KaiselBranchedShell
 
 If your app has a tabbed shell, this is where most of the rewrite
-happens. `AutoTabsScaffold` becomes `KaiselBranchedShell`, and each
-tab gets its own sealed route type for per-branch typing.
+happens. `AutoTabsScaffold` becomes `KaiselBranchedShell.specs`, and
+each tab gets its own sealed route type for per-branch typing.
 
 **Before** (auto_route):
 
@@ -294,48 +344,55 @@ final class ProductDetail extends ProductRoute {
 sealed class SettingsRoute extends KaiselRoute { const SettingsRoute(); }
 final class SettingsView extends SettingsRoute { const SettingsView(); }
 
-class MainShell extends StatefulWidget { /* ... */ }
-
-class _MainShellState extends State<MainShell> {
-  late final _homeRouter = KaiselRouter<HomeRoute>(initial: const HomeView());
-  late final _productRouter = KaiselRouter<ProductRoute>(initial: const ProductList());
-  late final _settingsRouter = KaiselRouter<SettingsRoute>(initial: const SettingsView());
-  late final _shell = BranchedShellRouter(branches: [_homeRouter, _productRouter, _settingsRouter]);
-
-  @override
-  Widget build(BuildContext context) {
-    return KaiselBranchedShell(
-      shell: _shell,
-      branches: [
-        KaiselBranch<HomeRoute>(router: _homeRouter, pageBuilder: (c, r) => switch (r) {
-          HomeView() => const HomeTabScreen(),
-        }),
-        KaiselBranch<ProductRoute>(router: _productRouter, pageBuilder: (c, r) => switch (r) {
-          ProductList() => const ProductListScreen(),
-          ProductDetail(:final id) => ProductDetailScreen(id: id),
-        }),
-        KaiselBranch<SettingsRoute>(router: _settingsRouter, pageBuilder: (c, r) => switch (r) {
-          SettingsView() => const SettingsScreen(),
-        }),
-      ],
-      chromeBuilder: (context, activeBranch, branchContent, switchBranch) => Scaffold(
-        body: branchContent,
-        bottomNavigationBar: BottomNavigationBar(
-          currentIndex: activeBranch,
-          onTap: switchBranch,
-          items: const [/* ... */],
-        ),
-      ),
-    );
-  }
-}
+// The shell owns the per-branch routers — no manual KaiselRouter to wire.
+KaiselBranchedShell.specs(
+  branches: [
+    KaiselBranchSpec<HomeRoute>(
+      initial: const HomeView(),
+      builder: (c, r) => switch (r) {
+        HomeView() => const HomeTabScreen(),
+      },
+    ),
+    KaiselBranchSpec<ProductRoute>(
+      initial: const ProductList(),
+      builder: (c, r) => switch (r) {
+        ProductList() => const ProductListScreen(),
+        ProductDetail(:final id) => ProductDetailScreen(id: id),
+      },
+    ),
+    KaiselBranchSpec<SettingsRoute>(
+      initial: const SettingsView(),
+      builder: (c, r) => switch (r) {
+        SettingsView() => const SettingsScreen(),
+      },
+    ),
+  ],
+  chromeBuilder: (context, activeBranch, branchContent, switchBranch) => Scaffold(
+    body: branchContent,
+    bottomNavigationBar: BottomNavigationBar(
+      currentIndex: activeBranch,
+      onTap: switchBranch,
+      items: const [/* ... */],
+    ),
+  ),
+);
 ```
 
-The notable thing is per-branch typing. Each tab's router takes a
-specific sealed type — `KaiselRouter<HomeRoute>`, not
-`KaiselRouter<AppRoute>`. The compiler will reject `_homeRouter.push(const ProductDetail('x'))`
-as a type error. That's the type safety the article talks about
-becoming load-bearing in your editor, not just on paper.
+`KaiselBranchedShell.specs` declares each branch's initial route and
+builder, and the shell owns the per-branch routers — no
+`StatefulWidget`, no manual `KaiselRouter` or `BranchedShellRouter`.
+(The explicit `KaiselBranchedShell(shell:, branches: [KaiselBranch(...)])`
+form stays available as the lower tier if you need to hold the routers
+yourself.)
+
+The notable thing is per-branch typing. Each `KaiselBranchSpec` takes
+a specific sealed type — `KaiselBranchSpec<HomeRoute>`, not a single
+shared `AppRoute` — so its router is typed too. The compiler will
+reject pushing a `ProductDetail` into the home branch as a type error.
+That's the type safety the article talks about becoming load-bearing
+in your editor, not just on paper. From inside a branch, reach the
+shell with `context.shell()` (a `KaiselShellController`: `.switchTo(i)`,
+`.activeBranch`, `.branchCount`, `.current`).
 
 State preservation across tab switches is on by default — you don't
 need a stateful variant the way auto_route does.

--- a/packages/kaisel/doc/migration/from-go-router.md
+++ b/packages/kaisel/doc/migration/from-go-router.md
@@ -502,8 +502,10 @@ router whose route type accepts the argument at runtime, so
 `context.push(const ProductDetail('42'))` "just works" from anywhere
 in the tree, the way `context.push('/products/42')` does. The trade
 is that a wrong-family route throws at runtime instead of compile
-time; `context.router<AppRoute>()` remains the typed escape hatch
-when you want the error at compile time.
+time — so kaisel treats the typed `context.router<AppRoute>().push(...)`
+as the idiomatic default (the family is compile-checked) and the terse
+`context.push(...)` as the go_router-shaped convenience you reach for
+when the brevity is worth that trade.
 
 **`routerConfig` setup.** `KaiselRouterConfig` is a `RouterConfig`
 you hand to `MaterialApp.router(routerConfig:)`, declared as a

--- a/packages/kaisel/doc/migration/from-go-router.md
+++ b/packages/kaisel/doc/migration/from-go-router.md
@@ -18,6 +18,16 @@ gap between these mental models is wider than the gap from auto_route
 to kaisel, and the migration is correspondingly more philosophical
 in places.
 
+The *surface*, though, is now close. kaisel has a
+`KaiselRouterConfig` that drops into `MaterialApp.router(routerConfig:)`
+exactly where `GoRouter` does, declared as a top-level `final` with
+no `StatefulWidget` or hand-rolled delegate. And it has terse
+`context.*` verbs — `context.push(const ProductDetail('42'))`,
+`context.pop()`, `context.set([...])` — that mirror go_router's
+`context.push('/path')` shape. So the day-to-day call sites read
+almost the same; what changes is what flows through them (typed
+values instead of strings).
+
 The mechanical translation is straightforward for simple apps. The
 work concentrates in three areas: the global `redirect:` callback
 (becomes a guard pipeline), `ShellRoute` / `StatefulShellRoute`
@@ -57,18 +67,20 @@ codec entirely.
 
 | go_router                                       | kaisel                                              |
 | ----------------------------------------------- | --------------------------------------------------- |
+| `final _router = GoRouter(...)`                 | `final _config = KaiselRouterConfig<AppRoute>(...)` |
+| `MaterialApp.router(routerConfig: _router)`     | `MaterialApp.router(routerConfig: _config)`         |
 | `GoRoute(path: '/products/:id', builder: ...)`  | `final class ProductDetail extends AppRoute` + a switch arm |
 | Path params `:id` parsed to `state.params['id']`| Constructor field `final String id`                 |
 | Query params `state.uri.queryParameters`        | Constructor fields on the route                     |
 | `extra: nonSerializableObject`                  | Another field on the route                          |
 | Global `redirect: (ctx, state) => ...`          | Guard function `(current, proposed) → stack` in the pipeline |
 | Per-route `redirect:`                           | Same pipeline; pattern-match on the route           |
-| `ShellRoute`                                    | A single-branch `KaiselBranchedShell` or custom     |
-| `StatefulShellRoute.indexedStack`               | `KaiselBranchedShell` with N branches               |
-| `context.go('/products/42')`                    | `context.router<AppRoute>().set([const Home(), ProductDetail('42')])` |
-| `context.push('/products/42')`                  | `context.router<AppRoute>().push(const ProductDetail('42'))` |
-| `context.pop()`                                 | `context.router<AppRoute>().pop()`                  |
-| `context.replace('/login')`                     | `context.router<AppRoute>().replaceTop(const Login())` |
+| `ShellRoute`                                    | `KaiselBranchedShell.specs` with one branch         |
+| `StatefulShellRoute.indexedStack`               | `KaiselBranchedShell.specs` with N branches         |
+| `context.push('/products/42')`                  | `context.push(const ProductDetail('42'))`           |
+| `context.go('/products/42')`                    | `context.set([const Home(), ProductDetail('42')])` (replace stack) or `context.replaceTop(...)` |
+| `context.pop()`                                 | `context.pop()`                                     |
+| `context.replace('/login')`                     | `context.replaceTop(const Login())`                 |
 | `go_router_builder` (optional codegen)          | Sealed types; no build step                         |
 | `errorBuilder:`                                 | An error route variant in your sealed type          |
 
@@ -94,6 +106,60 @@ Swap go_router for kaisel in `pubspec.yaml`:
 If you used `go_router_builder` for typed routes, drop both that and
 `build_runner` (if it isn't being used by something else). Delete
 any generated `*.g.dart` files associated with routing.
+
+Then replace the `GoRouter` instance itself. Where go_router has a
+top-level `final _router = GoRouter(...)` plugged into
+`MaterialApp.router(routerConfig:)`, kaisel has a top-level
+`final _config = KaiselRouterConfig<AppRoute>(...)` that fills the
+exact same slot:
+
+**Before** (go_router):
+
+```dart
+final _router = GoRouter(
+  initialLocation: '/home',
+  routes: [/* GoRoutes */],
+);
+
+class App extends StatelessWidget {
+  const App({super.key});
+  @override
+  Widget build(BuildContext context) =>
+      MaterialApp.router(routerConfig: _router);
+}
+```
+
+**After** (kaisel):
+
+```dart
+final _config = KaiselRouterConfig<AppRoute>(
+  initial: const Home(),
+  builder: (context, route) => switch (route) {
+    Home() => const HomeScreen(),
+    ProductList() => const ProductListScreen(),
+    ProductDetail(:final id) => ProductDetailScreen(id: id),
+    // ... other routes
+  },
+  // optional: guards:, pageWrapper:, modalBuilder:, codec:, fallback:
+);
+
+class App extends StatelessWidget {
+  const App({super.key});
+  @override
+  Widget build(BuildContext context) =>
+      MaterialApp.router(routerConfig: _config);
+}
+```
+
+Like `GoRouter`, `KaiselRouterConfig` is app-lifetime: a top-level
+`final`, no `StatefulWidget`, no manual `KaiselRouterDelegate`, no
+hand-rolled parser, no `dispose`. Omit `codec:` and the app is
+URL-less; pass `codec:` (and optionally `fallback:`) and it wires the
+route-information parser and `PlatformRouteInformationProvider` for
+you (step 6). `_config.router` exposes the bundled `KaiselRouter` if
+you need imperative access to the stack. The explicit
+delegate-plus-parser form still works as a lower tier when you want
+to assemble the pieces by hand.
 
 ### 2. Translate GoRoute definitions to sealed routes
 
@@ -125,9 +191,9 @@ final class ProductDetail extends AppRoute {
   List<Object?> get props => [id];
 }
 
-// 2. Handle it in the page builder.
-KaiselRouterDelegate<AppRoute>(
-  router: router,
+// 2. Handle it in the config's page builder (the `builder:` from step 1).
+KaiselRouterConfig<AppRoute>(
+  initial: const Home(),
   builder: (context, route) => switch (route) {
     Home() => const HomeScreen(),
     ProductDetail(:final id) => ProductDetailScreen(id: id),
@@ -235,8 +301,9 @@ List<AppRoute> authGuard(List<AppRoute> current, List<AppRoute> proposed) {
   return proposed;
 }
 
-final router = KaiselRouter<AppRoute>(
+final _config = KaiselRouterConfig<AppRoute>(
   initial: isLoggedIn ? const Home() : const Login(),
+  builder: (context, route) => switch (route) { /* ... */ },
   guards: [authGuard],
 );
 ```
@@ -245,8 +312,9 @@ Multiple cross-cutting concerns compose as a list of guards, each
 receiving the output of the previous:
 
 ```dart
-KaiselRouter<AppRoute>(
+KaiselRouterConfig<AppRoute>(
   initial: const Home(),
+  builder: (context, route) => switch (route) { /* ... */ },
   guards: [authGuard, featureFlagGuard, entitlementGuard],
 )
 ```
@@ -300,52 +368,52 @@ final class ProductDetail extends ProductRoute {
   List<Object?> get props => [id];
 }
 
-// Shell host widget.
-class _AppShellState extends State<AppShell> {
-  late final _homeRouter = KaiselRouter<HomeRoute>(initial: const HomeView());
-  late final _productRouter = KaiselRouter<ProductRoute>(initial: const ProductList());
-  late final _shell = BranchedShellRouter(branches: [_homeRouter, _productRouter]);
-
-  @override
-  Widget build(BuildContext context) {
-    return KaiselBranchedShell(
-      shell: _shell,
-      branches: [
-        KaiselBranch<HomeRoute>(
-          router: _homeRouter,
-          pageBuilder: (c, r) => switch (r) {
-            HomeView() => const HomeScreen(),
-          },
-        ),
-        KaiselBranch<ProductRoute>(
-          router: _productRouter,
-          pageBuilder: (c, r) => switch (r) {
-            ProductList() => const ProductListScreen(),
-            ProductDetail(:final id) => ProductDetailScreen(id: id),
-          },
-        ),
-      ],
-      chromeBuilder: (context, activeBranch, branchContent, switchBranch) {
-        return Scaffold(
-          body: branchContent,
-          bottomNavigationBar: BottomNavigationBar(
-            currentIndex: activeBranch,
-            onTap: switchBranch,
-            items: const [/* ... */],
-          ),
-        );
+// Declarative branched shell — the shell owns the per-branch routers.
+KaiselBranchedShell.specs(
+  branches: [
+    KaiselBranchSpec<HomeRoute>(
+      initial: const HomeView(),
+      builder: (c, r) => switch (r) {
+        HomeView() => const HomeScreen(),
       },
+    ),
+    KaiselBranchSpec<ProductRoute>(
+      initial: const ProductList(),
+      builder: (c, r) => switch (r) {
+        ProductList() => const ProductListScreen(),
+        ProductDetail(:final id) => ProductDetailScreen(id: id),
+      },
+    ),
+  ],
+  chromeBuilder: (context, activeBranch, branchContent, switchBranch) {
+    return Scaffold(
+      body: branchContent,
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: activeBranch,
+        onTap: switchBranch,
+        items: const [/* ... */],
+      ),
     );
-  }
-}
+  },
+);
 ```
 
-Per-branch typing is doing real work here. Each tab's `KaiselRouter`
-is typed to that tab's sealed family. The compiler will reject
-`_homeRouter.push(const ProductDetail('x'))` as a type error —
-you can't accidentally push a product route into the home tab's
-stack. This is the type safety go_router's table can't give you
-even with codegen.
+`KaiselBranchedShell.specs` is the natural target for migrating
+`StatefulShellRoute`: you declare each branch's initial route and
+builder, and the shell owns the per-branch routers for you — no
+manual `KaiselRouter` or `BranchedShellRouter` to wire. (The
+explicit `KaiselBranchedShell(shell:, branches: [KaiselBranch(...)])`
+form is still available as the lower tier when you need to hold the
+routers yourself.)
+
+Per-branch typing is doing real work here. Each `KaiselBranchSpec`
+is typed to that tab's sealed family, so the branch's own router is
+too — the compiler will reject pushing a `ProductDetail` into the
+home branch as a type error. This is the type safety go_router's
+table can't give you even with codegen. From inside a branch, reach
+the shell with `context.shell()` (a `KaiselShellController`:
+`.switchTo(i)`, `.activeBranch`, `.branchCount`, `.current`).
+For an adaptive branch, use `KaiselBranchSpec.adaptive(initial:, builder:)`.
 
 ### 6. Wire up the codec
 
@@ -354,23 +422,14 @@ auto_route already has typed routes and a codegen-driven parser.
 go_router migration almost always needs this step because you
 likely have deep links to maintain.
 
-If you don't use deep links at all, use a no-op parser:
+If you don't use deep links at all, omit `codec:` from
+`KaiselRouterConfig` entirely — the app stays URL-less and there's no
+parser to write.
 
-```dart
-class _NoopParser extends RouteInformationParser<KaiselConfig<AppRoute>> {
-  _NoopParser(this.router);
-  final KaiselRouter<AppRoute> router;
-  @override
-  Future<KaiselConfig<AppRoute>> parseRouteInformation(
-    RouteInformation routeInformation,
-  ) async {
-    return KaiselConfig<AppRoute>(mainStack: router.stack);
-  }
-}
-```
-
-If you do, write a real codec. The codec maps `Uri ↔ KaiselConfig`,
-and you register it with the parser:
+If you do, write a real codec and pass it as `codec:` (with an
+optional `fallback:`). `KaiselRouterConfig` wires the
+route-information parser and `PlatformRouteInformationProvider` for
+you. The codec maps `Uri ↔ KaiselConfig`:
 
 ```dart
 class AppCodec extends KaiselConfigCodec<AppRoute> {
@@ -430,6 +489,27 @@ The codec only handles `ProductDetailById`. The other variant is
 in-app only, and the screen pattern-matches on which it received.
 This replaces go_router's `extra` field with something type-checked.
 
+## What's now at parity
+
+A few things that used to be on this list have landed, and they're
+the ones that mattered most for go_router users:
+
+**`context.push` ergonomics.** The terse `context.*` verbs —
+`context.push`, `context.pop`, `context.replaceTop`,
+`context.pushOrReplaceTop`, `context.set`, and `await context.run<T>(...)`
+— give you go_router-shaped call sites. They resolve the nearest
+router whose route type accepts the argument at runtime, so
+`context.push(const ProductDetail('42'))` "just works" from anywhere
+in the tree, the way `context.push('/products/42')` does. The trade
+is that a wrong-family route throws at runtime instead of compile
+time; `context.router<AppRoute>()` remains the typed escape hatch
+when you want the error at compile time.
+
+**`routerConfig` setup.** `KaiselRouterConfig` is a `RouterConfig`
+you hand to `MaterialApp.router(routerConfig:)`, declared as a
+top-level `final` — the exact shape of `final _router = GoRouter(...)`.
+No `StatefulWidget`, no manual delegate or parser. See step 1.
+
 ## What kaisel doesn't yet do at parity
 
 Be honest with yourself about whether these matter before migrating.
@@ -486,7 +566,8 @@ main, do the rewrite, regression-test, ship.
 
 The reason big-bang is the right answer is that route-related code
 in your app is more interconnected than you remember. Every screen
-that uses `context.go(...)` is coupled to your route table. Every
+that uses `context.go(...)` / `context.push(...)` is coupled to your
+route table. Every
 guard touches the redirect callback. Every deep link touches the
 parser. Switching the router under any of these means switching
 them all. There's no clean line to draw across the codebase that

--- a/packages/kaisel/example/README.md
+++ b/packages/kaisel/example/README.md
@@ -1,16 +1,33 @@
 # kaisel example
 
-Six entry points, each demonstrating a slice of the library.
+Seven entry points, each demonstrating a slice of the library.
 Pick one with `-t`:
 
 | Entry point | What it shows |
 | --- | --- |
+| `lib/main_terse.dart` | The terse ergonomics layer: a minimal before/after app wiring `KaiselRouterConfig` into `MaterialApp.router` and navigating with `context.push`/`context.pop` |
 | `lib/main.dart` | The main example: bottom-nav `KaiselBranchedShell` with per-tab typed routes, modal flows, modules, and URL deep-linking via codec |
 | `lib/main_adaptive.dart` | Adaptive layouts at the main delegate (v0.8) with `pushOrReplaceTop` (v0.11) for in-place master-detail swaps |
 | `lib/main_shell_adaptive.dart` | Adaptive layout *inside a shell branch* (v0.9): one tab is master-detail, the other isn't, shell stays at the bottom |
 | `lib/main_nested_flows.dart` | Nested modal flows (v0.10): a payment flow opens an "add card" flow on top of itself, both layers visible at once |
 | `lib/main_transitions.dart` | Route-pair transitions (v0.11): pageWrapper pattern-matches on `(ctx.previous, ctx.route)` to pick custom Page subclasses per route pair |
-| `lib/main_media_cataloguer.dart` | A desktop-style app: top-level auth state machine (`router.set` swaps `LoginRoute` ↔ `ShellHost`), a cross-fade `pageWrapper` between them, a branched shell with per-branch typed routes + nested stacks, and a breadcrumb driven by `KaiselListenableBuilder` |
+| `lib/main_media_cataloguer.dart` | A desktop-style app: top-level auth state machine (`router.set` swaps `LoginRoute` ↔ `ShellHost`), a cross-fade `pageWrapper` between them, a branched shell with per-branch typed routes + nested stacks, and a breadcrumb driven by `KaiselListenableBuilder`. Wired with `KaiselRouterConfig` + `KaiselBranchedShell.specs` + `context.shell()` |
+
+## `lib/main_terse.dart`
+
+The terse ergonomics layer. A minimal before/after app: a top-level
+`final KaiselRouterConfig<R>` handed straight to `MaterialApp.router`
+(`routerConfig:`) — no `StatefulWidget`, no manual delegate, parser, or
+`dispose`. Call sites use the terse `context.*` nav: `context.push(route)`
+and `context.pop()`.
+
+```sh
+flutter run -t lib/main_terse.dart
+```
+
+`KaiselRouterConfig` takes an optional `codec:` for URL deep-linking;
+`context.router<R>()` stays available as the typed escape hatch when you
+need the router directly.
 
 ## `lib/main.dart`
 

--- a/packages/kaisel/example/lib/main.dart
+++ b/packages/kaisel/example/lib/main.dart
@@ -602,7 +602,7 @@ class _ProfileScreen extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             TextButton(
-              onPressed: () => context.branchedShell().switchTo(0),
+              onPressed: () => context.shell().switchTo(0),
               child: const Text('Go to Home tab'),
             ),
             const SizedBox(height: 12),

--- a/packages/kaisel/example/lib/main_media_cataloguer.dart
+++ b/packages/kaisel/example/lib/main_media_cataloguer.dart
@@ -469,64 +469,38 @@ class _MasterDetailScaffold extends StatelessWidget {
 // Holds three branches, each with its own typed router. The shell's
 // own chrome (sidebar + breadcrumb) is built by the chrome builder.
 
-class _ShellHost extends StatefulWidget {
+// Declarative branches: the shell creates, owns, and disposes the per-branch
+// routers for us. (Before, this was a StatefulWidget holding three
+// `KaiselRouter`s + a `BranchedShellRouter` and disposing all four by hand, and
+// threading the routers through the chrome.)
+class _ShellHost extends StatelessWidget {
   const _ShellHost();
-  @override
-  State<_ShellHost> createState() => _ShellHostState();
-}
-
-class _ShellHostState extends State<_ShellHost> {
-  late final KaiselRouter<HomeRoute> _homeRouter = KaiselRouter<HomeRoute>(
-    initial: const HomeView(),
-  );
-  late final KaiselRouter<LibraryRoute> _libraryRouter =
-      KaiselRouter<LibraryRoute>(initial: const LibraryView());
-  late final KaiselRouter<TestRoute> _testRouter = KaiselRouter<TestRoute>(
-    initial: const TestHome(),
-  );
-
-  late final BranchedShellRouter _shell = BranchedShellRouter(
-    branches: [_homeRouter, _libraryRouter, _testRouter],
-  );
-
-  @override
-  void dispose() {
-    _shell.dispose();
-    _homeRouter.dispose();
-    _libraryRouter.dispose();
-    _testRouter.dispose();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {
-    return KaiselBranchedShell(
-      shell: _shell,
+    return KaiselBranchedShell.specs(
       branches: [
-        KaiselBranch<HomeRoute>(
-          router: _homeRouter,
-          pageBuilder: (context, route) => switch (route) {
+        KaiselBranchSpec<HomeRoute>(
+          initial: const HomeView(),
+          builder: (context, route) => switch (route) {
             HomeView() => const _HomeScreen(),
           },
         ),
-        KaiselBranch<LibraryRoute>(
-          router: _libraryRouter,
-          pageBuilder: (context, route) => switch (route) {
+        KaiselBranchSpec<LibraryRoute>(
+          initial: const LibraryView(),
+          builder: (context, route) => switch (route) {
             LibraryView() => const _LibraryScreen(),
           },
         ),
-        KaiselBranch<TestRoute>.adaptive(
-          router: _testRouter,
-          pageBuilder: _testAdaptiveBuilder,
+        KaiselBranchSpec<TestRoute>.adaptive(
+          initial: const TestHome(),
+          builder: _testAdaptiveBuilder,
         ),
       ],
       chromeBuilder: (context, active, branchContent, switchBranch) {
         return _AppChrome(
           activeBranchIndex: active,
           onSwitchBranch: switchBranch,
-          homeRouter: _homeRouter,
-          libraryRouter: _libraryRouter,
-          testRouter: _testRouter,
           branchContent: branchContent,
         );
       },
@@ -540,17 +514,11 @@ class _AppChrome extends StatelessWidget {
   const _AppChrome({
     required this.activeBranchIndex,
     required this.onSwitchBranch,
-    required this.homeRouter,
-    required this.libraryRouter,
-    required this.testRouter,
     required this.branchContent,
   });
 
   final int activeBranchIndex;
   final void Function(int) onSwitchBranch;
-  final KaiselRouter<HomeRoute> homeRouter;
-  final KaiselRouter<LibraryRoute> libraryRouter;
-  final KaiselRouter<TestRoute> testRouter;
   final Widget branchContent;
 
   @override
@@ -598,14 +566,7 @@ class _AppChrome extends StatelessWidget {
                     icon: const Icon(Icons.arrow_forward_ios),
                   ),
                   const SizedBox(width: 12),
-                  Expanded(
-                    child: _InnerNavBar(
-                      activeBranchIndex: activeBranchIndex,
-                      homeRouter: homeRouter,
-                      libraryRouter: libraryRouter,
-                      testRouter: testRouter,
-                    ),
-                  ),
+                  Expanded(child: const _InnerNavBar()),
                   IconButton(
                     iconSize: 14,
                     color: Colors.white70,
@@ -641,39 +602,29 @@ class _AppChrome extends StatelessWidget {
 /// Inner back/forward + breadcrumb. Hooks into the active branch's
 /// router so the back arrow pops within the current branch only.
 class _InnerNavBar extends StatelessWidget {
-  const _InnerNavBar({
-    required this.activeBranchIndex,
-    required this.homeRouter,
-    required this.libraryRouter,
-    required this.testRouter,
-  });
-
-  final int activeBranchIndex;
-  final KaiselRouter<HomeRoute> homeRouter;
-  final KaiselRouter<LibraryRoute> libraryRouter;
-  final KaiselRouter<TestRoute> testRouter;
+  const _InnerNavBar();
 
   @override
   Widget build(BuildContext context) {
-    // Pick the active router based on the active branch index. We
-    // listen to it so the breadcrumb updates when the branch's stack
-    // changes (push, pop, replaceTop).
-    final activeRouter = switch (activeBranchIndex) {
-      0 => homeRouter,
-      1 => libraryRouter,
-      _ => testRouter,
-    };
+    // The shell exposes the active branch via context.shell() — no need to
+    // hold the per-branch routers. It notifies on branch switches and on
+    // active-stack changes, so the breadcrumb stays live.
+    final shell = context.shell();
 
     return ListenableBuilder(
-      listenable: activeRouter.asListenable(),
+      listenable: shell,
       builder: (context, _) {
-        final (label, path, canPop) = _describeActive();
+        final current = shell.current;
+        final (label, path, canPop) = _describeActive(
+          shell.activeBranch,
+          current,
+        );
         return Row(
           children: [
             IconButton(
               iconSize: 16,
               color: canPop ? Colors.white : Colors.white38,
-              onPressed: canPop ? _popActive : null,
+              onPressed: canPop ? current.pop : null,
               icon: const Icon(Icons.arrow_back_ios_new),
             ),
             IconButton(
@@ -705,19 +656,19 @@ class _InnerNavBar extends StatelessWidget {
     );
   }
 
-  /// Returns (human-readable label, URL path, whether back is enabled)
-  /// based on the active branch and its current stack.
-  (String, String, bool) _describeActive() {
+  /// Returns (human-readable label, URL path, whether back is enabled) for the
+  /// active branch [activeBranchIndex] and its [current] router.
+  (String, String, bool) _describeActive(
+    int activeBranchIndex,
+    KaiselNavigator current,
+  ) {
     switch (activeBranchIndex) {
       case 0:
-        return ('Home', '/home', homeRouter.stack.length > 1);
+        return ('Home', '/home', current.canPop);
       case 1:
-        return ('Library', '/library', libraryRouter.stack.length > 1);
+        return ('Library', '/library', current.canPop);
       default:
-        final stack = testRouter.stack;
-        final top = stack.last;
-        return switch (top) {
-          TestHome() => ('Test', '/test', false),
+        return switch (current.stack.last) {
           CollectionView(:final id) => (
             'Collection - $id',
             '/collection/$id',
@@ -728,18 +679,8 @@ class _InnerNavBar extends StatelessWidget {
             '/collection/$collectionId/$fileName',
             true,
           ),
+          _ => ('Test', '/test', false),
         };
-    }
-  }
-
-  void _popActive() {
-    switch (activeBranchIndex) {
-      case 0:
-        homeRouter.pop();
-      case 1:
-        libraryRouter.pop();
-      default:
-        testRouter.pop();
     }
   }
 }

--- a/packages/kaisel/example/lib/main_media_cataloguer.dart
+++ b/packages/kaisel/example/lib/main_media_cataloguer.dart
@@ -187,7 +187,7 @@ class _LoginScreen extends StatelessWidget {
               onPressed: () {
                 // The auth state is the stack. Replace LoginRoute with
                 // ShellHost; the page wrapper cross-fades the swap.
-                context.router<AppRoute>().set(const [ShellHost()]);
+                context.set(const [ShellHost()]);
               },
               child: const Text(
                 'Go to Content View',
@@ -253,9 +253,7 @@ class _TestHomeScreen extends StatelessWidget {
             const SizedBox(height: 12),
             TextButton(
               onPressed: () {
-                context.router<TestRoute>().push(
-                  const CollectionView(_demoCollectionId),
-                );
+                context.push(const CollectionView(_demoCollectionId));
               },
               child: const Text(
                 'Open demo collection',
@@ -333,7 +331,7 @@ class _CollectionScreen extends StatelessWidget {
                     // detail is already on top. Tapping a different
                     // video updates the right pane in place instead
                     // of stacking three entries.
-                    context.router<TestRoute>().pushOrReplaceTop(
+                    context.pushOrReplaceTop(
                       VideoPlayerView(collectionId: id, fileName: fileName),
                     );
                   },
@@ -393,7 +391,7 @@ class _VideoPlayerScreen extends StatelessWidget {
               top: 8,
               left: 8,
               child: IconButton(
-                onPressed: () => context.router<TestRoute>().pop(),
+                onPressed: () => context.pop(),
                 icon: const Icon(Icons.arrow_back, color: Color(0xFF8E2C3A)),
                 tooltip: 'Back to collection',
               ),
@@ -614,7 +612,7 @@ class _AppChrome extends StatelessWidget {
                     tooltip: 'Sign out',
                     onPressed: () {
                       // Return to login surface. The page wrapper cross-fades.
-                      context.router<AppRoute>().set(const [LoginRoute()]);
+                      context.set(const [LoginRoute()]);
                     },
                     icon: const Icon(Icons.logout),
                   ),
@@ -831,41 +829,23 @@ class _SidebarItem extends StatelessWidget {
 }
 
 // App
+//
+// The whole router setup is one top-level value: no StatefulWidget, no manual
+// KaiselRouterDelegate, no hand-rolled parser, no dispose. (This replaced a
+// ~30-line StatefulWidget plus a `_NoopParser` class.)
 
-class MediaCataloguerApp extends StatefulWidget {
-  const MediaCataloguerApp({super.key});
-  @override
-  State<MediaCataloguerApp> createState() => _MediaCataloguerAppState();
-}
+final _config = KaiselRouterConfig<AppRoute>(
+  initial: const LoginRoute(),
+  builder: (context, route) => switch (route) {
+    LoginRoute() => const _LoginScreen(),
+    ShellHost() => const _ShellHost(),
+  },
+  pageWrapper: _appPageWrapper,
+);
 
-class _MediaCataloguerAppState extends State<MediaCataloguerApp> {
-  late final KaiselRouter<AppRoute> _router;
-  late final KaiselRouterDelegate<AppRoute> _delegate;
-
-  @override
-  void initState() {
-    super.initState();
-    _router = KaiselRouter<AppRoute>(initial: const LoginRoute());
-    _delegate = KaiselRouterDelegate<AppRoute>(
-      router: _router,
-      builder: (context, route) => switch (route) {
-        LoginRoute() => const _LoginScreen(),
-        ShellHost() => const _ShellHost(),
-      },
-      pageWrapper: _appPageWrapper,
-    );
-  }
-
-  @override
-  void dispose() {
-    _delegate.dispose();
-    _router.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return MaterialApp.router(
+void main() {
+  runApp(
+    MaterialApp.router(
       title: '[DEV] Media Cataloguer',
       debugShowCheckedModeBanner: false,
       theme: ThemeData(
@@ -875,19 +855,7 @@ class _MediaCataloguerAppState extends State<MediaCataloguerApp> {
         ),
         useMaterial3: true,
       ),
-      routerDelegate: _delegate,
-      routeInformationParser: _NoopParser(_router),
-    );
-  }
+      routerConfig: _config,
+    ),
+  );
 }
-
-class _NoopParser extends RouteInformationParser<KaiselConfig<AppRoute>> {
-  _NoopParser(this.router);
-  final KaiselRouter<AppRoute> router;
-  @override
-  Future<KaiselConfig<AppRoute>> parseRouteInformation(
-    RouteInformation routeInformation,
-  ) async => KaiselConfig<AppRoute>(mainStack: router.stack);
-}
-
-void main() => runApp(const MediaCataloguerApp());

--- a/packages/kaisel/example/lib/main_terse.dart
+++ b/packages/kaisel/example/lib/main_terse.dart
@@ -1,6 +1,5 @@
 // Ergonomics prototype: the same app, written with the new convenience layer.
 //
-// ─────────────────────────────────────────────────────────────────────────
 // BEFORE — the plumbing people call "low-level like Navigator 2.0":
 //
 //   class _App extends StatefulWidget { ... }
@@ -24,7 +23,6 @@
 //   context.router<AppRoute>().pop();
 //
 // AFTER — below. Top-level config, no StatefulWidget, no parser, terse calls.
-// ─────────────────────────────────────────────────────────────────────────
 
 import 'package:flutter/material.dart';
 import 'package:kaisel/kaisel.dart';

--- a/packages/kaisel/example/lib/main_terse.dart
+++ b/packages/kaisel/example/lib/main_terse.dart
@@ -72,7 +72,8 @@ class _HomeScreen extends StatelessWidget {
       appBar: AppBar(title: const Text('Home')),
       body: Center(
         child: ElevatedButton(
-          // Terse, go_router-shaped — no `router<AppRoute>()` ceremony.
+          // Terse convenience (runtime family check). The idiomatic default
+          // is the typed context.router<AppRoute>().push(const ProductDetail(...)).
           onPressed: () => context.push(const ProductDetail('sku-42')),
           child: const Text('Open product'),
         ),

--- a/packages/kaisel/example/lib/main_terse.dart
+++ b/packages/kaisel/example/lib/main_terse.dart
@@ -1,0 +1,102 @@
+// Ergonomics prototype: the same app, written with the new convenience layer.
+//
+// ─────────────────────────────────────────────────────────────────────────
+// BEFORE — the plumbing people call "low-level like Navigator 2.0":
+//
+//   class _App extends StatefulWidget { ... }
+//   class _AppState extends State<_App> {
+//     late final KaiselRouter<AppRoute> _router;
+//     late final KaiselRouterDelegate<AppRoute> _delegate;
+//     @override void initState() {
+//       super.initState();
+//       _router = KaiselRouter<AppRoute>(initial: const Home());
+//       _delegate = KaiselRouterDelegate<AppRoute>(router: _router, builder: …);
+//     }
+//     @override void dispose() { _delegate.dispose(); _router.dispose(); super.dispose(); }
+//     @override Widget build(_) => MaterialApp.router(
+//       routerDelegate: _delegate,
+//       routeInformationParser: _NoopParser(_router),   // hand-rolled
+//     );
+//   }
+//
+//   // call sites:
+//   context.router<AppRoute>().push(const ProductDetail('42'));
+//   context.router<AppRoute>().pop();
+//
+// AFTER — below. Top-level config, no StatefulWidget, no parser, terse calls.
+// ─────────────────────────────────────────────────────────────────────────
+
+import 'package:flutter/material.dart';
+import 'package:kaisel/kaisel.dart';
+
+sealed class AppRoute extends KaiselRoute {
+  const AppRoute();
+}
+
+final class Home extends AppRoute {
+  const Home();
+}
+
+final class ProductDetail extends AppRoute {
+  const ProductDetail(this.id);
+  final String id;
+
+  @override
+  List<Object?> get props => [id];
+}
+
+// One value. No StatefulWidget, no manual delegate/parser, no dispose.
+final _config = KaiselRouterConfig<AppRoute>(
+  initial: const Home(),
+  builder: (context, route) => switch (route) {
+    Home() => const _HomeScreen(),
+    ProductDetail(:final id) => _DetailScreen(id: id),
+  },
+);
+
+void main() {
+  runApp(
+    MaterialApp.router(
+      // You keep your own MaterialApp — theme, title, everything.
+      title: 'kaisel — terse',
+      theme: ThemeData(useMaterial3: true, colorSchemeSeed: Colors.indigo),
+      routerConfig: _config,
+    ),
+  );
+}
+
+class _HomeScreen extends StatelessWidget {
+  const _HomeScreen();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Home')),
+      body: Center(
+        child: ElevatedButton(
+          // Terse, go_router-shaped — no `router<AppRoute>()` ceremony.
+          onPressed: () => context.push(const ProductDetail('sku-42')),
+          child: const Text('Open product'),
+        ),
+      ),
+    );
+  }
+}
+
+class _DetailScreen extends StatelessWidget {
+  const _DetailScreen({required this.id});
+  final String id;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Product $id')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () => context.pop(),
+          child: const Text('Back'),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/kaisel/lib/kaisel.dart
+++ b/packages/kaisel/lib/kaisel.dart
@@ -22,6 +22,7 @@ export 'src/kaisel_branched_shell.dart'
         BranchedShellRouter,
         BranchedShellScope,
         KaiselBranch,
+        KaiselBranchSpec,
         KaiselBranchedShell,
         KaiselBranchedShellChromeBuilder,
         KaiselBranchedShellContextX;

--- a/packages/kaisel/lib/kaisel.dart
+++ b/packages/kaisel/lib/kaisel.dart
@@ -21,6 +21,7 @@ export 'src/kaisel_branched_shell.dart'
     show
         BranchedShellRouter,
         KaiselBranch,
+        KaiselBranchContentBuilder,
         KaiselBranchSpec,
         KaiselBranchedShell,
         KaiselBranchedShellChromeBuilder;

--- a/packages/kaisel/lib/kaisel.dart
+++ b/packages/kaisel/lib/kaisel.dart
@@ -20,12 +20,10 @@ export 'src/kaisel_adaptive.dart'
 export 'src/kaisel_branched_shell.dart'
     show
         BranchedShellRouter,
-        BranchedShellScope,
         KaiselBranch,
         KaiselBranchSpec,
         KaiselBranchedShell,
-        KaiselBranchedShellChromeBuilder,
-        KaiselBranchedShellContextX;
+        KaiselBranchedShellChromeBuilder;
 export 'src/kaisel_inner_navigator.dart';
 export 'src/kaisel_listenable.dart'
     show KaiselListenableBuilder, KaiselRouterListenable;
@@ -39,10 +37,4 @@ export 'src/kaisel_router_delegate.dart'
     show KaiselModalBuilder, KaiselPageBuilder, KaiselRouterDelegate;
 export 'src/kaisel_scope.dart';
 export 'src/kaisel_shell.dart'
-    show
-        KaiselBranchScope,
-        KaiselShellBuildContextX,
-        KaiselShell,
-        KaiselShellChromeBuilder,
-        ShellRouter,
-        ShellScope;
+    show KaiselBranchScope, KaiselShell, KaiselShellChromeBuilder, ShellRouter;

--- a/packages/kaisel/lib/kaisel.dart
+++ b/packages/kaisel/lib/kaisel.dart
@@ -33,6 +33,7 @@ export 'src/kaisel_page_scope.dart' show KaiselPageScope;
 export 'src/kaisel_page_wrapper.dart'
     show KaiselPageWrapper, KaiselPageWrapperContext;
 export 'src/kaisel_route_information_parser.dart';
+export 'src/kaisel_router_config.dart' show KaiselRouterConfig;
 export 'src/kaisel_router_delegate.dart'
     show KaiselModalBuilder, KaiselPageBuilder, KaiselRouterDelegate;
 export 'src/kaisel_scope.dart';

--- a/packages/kaisel/lib/src/kaisel_branched_shell.dart
+++ b/packages/kaisel/lib/src/kaisel_branched_shell.dart
@@ -33,7 +33,8 @@ import 'kaisel_scope.dart';
 /// (can-pop and pop on the active branch for back handling); typed
 /// pushes happen on the user's own typed router references, or via
 /// `context.router<BranchR>()` inside a branch screen.
-class BranchedShellRouter extends ChangeNotifier implements KaiselNestedHandle {
+class BranchedShellRouter extends ChangeNotifier
+    implements KaiselNestedHandle, KaiselShellController {
   /// Create a shell aggregating [branches]. Each entry is typically a
   /// `KaiselRouter<BranchR>` for some sealed `BranchR`.
   BranchedShellRouter({
@@ -59,12 +60,14 @@ class BranchedShellRouter extends ChangeNotifier implements KaiselNestedHandle {
   List<KaiselNavigator> get branches => _branches;
 
   /// Index of the currently selected branch.
+  @override
   int get activeBranch => _activeBranch;
 
   /// The currently selected branch (as the non-generic view).
   KaiselNavigator get current => _branches[_activeBranch];
 
   /// Number of branches.
+  @override
   int get branchCount => _branches.length;
 
   /// Whether `pop` on the active branch would remove a route.
@@ -75,6 +78,7 @@ class BranchedShellRouter extends ChangeNotifier implements KaiselNestedHandle {
   Future<bool> popCurrent() => current.pop();
 
   /// Select a different branch. No-op if [branch] is already active.
+  @override
   void switchTo(int branch) {
     if (branch < 0 || branch >= _branches.length) {
       throw RangeError.range(branch, 0, _branches.length - 1, 'branch');
@@ -357,21 +361,24 @@ class _KaiselBranchedShellState extends State<KaiselBranchedShell> {
       },
       child: BranchedShellScope(
         shell: widget.shell,
-        child: ShellChromeScope(
-          accessorHint: 'context.branchedShell()',
-          child: Builder(
-            builder: (context) {
-              final branchContent = IndexedStack(
-                index: widget.shell.activeBranch,
-                children: widget.branches,
-              );
-              return widget.chromeBuilder(
-                context,
-                widget.shell.activeBranch,
-                branchContent,
-                widget.shell.switchTo,
-              );
-            },
+        child: KaiselShellScope(
+          controller: widget.shell,
+          child: ShellChromeScope(
+            accessorHint: 'context.branchedShell()',
+            child: Builder(
+              builder: (context) {
+                final branchContent = IndexedStack(
+                  index: widget.shell.activeBranch,
+                  children: widget.branches,
+                );
+                return widget.chromeBuilder(
+                  context,
+                  widget.shell.activeBranch,
+                  branchContent,
+                  widget.shell.switchTo,
+                );
+              },
+            ),
           ),
         ),
       ),

--- a/packages/kaisel/lib/src/kaisel_branched_shell.dart
+++ b/packages/kaisel/lib/src/kaisel_branched_shell.dart
@@ -64,6 +64,7 @@ class BranchedShellRouter extends ChangeNotifier
   int get activeBranch => _activeBranch;
 
   /// The currently selected branch (as the non-generic view).
+  @override
   KaiselNavigator get current => _branches[_activeBranch];
 
   /// Number of branches.
@@ -230,6 +231,81 @@ class _KaiselBranchState<R extends KaiselRoute> extends State<KaiselBranch<R>> {
   }
 }
 
+/// A declarative branch for [KaiselBranchedShell.specs]: the branch's [initial]
+/// route and its `builder`, with no [KaiselRouter] or [KaiselBranch] to wire by
+/// hand. The shell creates one router per spec, owns it (so each branch's stack
+/// survives tab switches), and disposes it.
+///
+/// Each spec keeps its own route type [R], so a heterogeneous
+/// `List<KaiselBranchSpec>` still produces correctly-typed routers and
+/// branches.
+class KaiselBranchSpec<R extends KaiselRoute> {
+  /// A branch with a simple per-route [builder].
+  const KaiselBranchSpec({
+    required this.initial,
+    required KaiselPageBuilder<R> builder,
+    this.guards = const [],
+    this.pageWrapper,
+    this.scope,
+  }) : _builder = builder,
+       _adaptiveBuilder = null;
+
+  /// A branch with an adaptive [builder] (master-detail absorption).
+  const KaiselBranchSpec.adaptive({
+    required this.initial,
+    required KaiselAdaptivePageBuilder<R> builder,
+    this.guards = const [],
+    this.pageWrapper,
+    this.scope,
+  }) : _builder = null,
+       _adaptiveBuilder = builder;
+
+  /// The branch's initial route.
+  final R initial;
+
+  /// Guards applied to this branch's router.
+  final List<KaiselGuard<R>> guards;
+
+  /// Optional per-route [Page] wrapper for this branch.
+  final KaiselPageWrapper<R>? pageWrapper;
+
+  /// Optional wrapper for the branch's content (DI containers, etc.).
+  final Widget Function(BuildContext context, Widget child)? scope;
+
+  final KaiselPageBuilder<R>? _builder;
+  final KaiselAdaptivePageBuilder<R>? _adaptiveBuilder;
+
+  /// Create this branch's router. Called once by the shell.
+  KaiselRouter<R> createRouter() =>
+      KaiselRouter<R>(initial: initial, guards: guards);
+
+  /// Build this branch's widget around [router] (the one [createRouter]
+  /// returned). Non-generic in [router] so the shell can keep a heterogeneous
+  /// list of specs; the cast is sound because the shell pairs each spec with
+  /// its own router.
+  Widget buildBranch(KaiselNavigator router) {
+    final typed = router as KaiselRouter<R>;
+    switch ((_builder, _adaptiveBuilder)) {
+      case (final builder?, _):
+        return KaiselBranch<R>(
+          router: typed,
+          pageBuilder: builder,
+          pageWrapper: pageWrapper,
+          scope: scope,
+        );
+      case (_, final adaptive?):
+        return KaiselBranch<R>.adaptive(
+          router: typed,
+          pageBuilder: adaptive,
+          pageWrapper: pageWrapper,
+          scope: scope,
+        );
+      case _:
+        throw StateError('KaiselBranchSpec has no builder.');
+    }
+  }
+}
+
 /// Signature for the chrome around a [KaiselBranchedShell] — typically a
 /// [Scaffold] with a bottom nav bar.
 typedef KaiselBranchedShellChromeBuilder =
@@ -272,24 +348,43 @@ typedef KaiselBranchedShellChromeBuilder =
 /// branch's typed router; `context.branchedShell()` resolves to the
 /// enclosing [BranchedShellRouter] for `switchTo` etc.
 class KaiselBranchedShell extends StatefulWidget {
-  /// Create a branched shell driven by [shell] with one widget per
-  /// branch in [branches]. The length of [branches] must equal
-  /// `shell.branchCount`.
+  /// Create a branched shell driven by [shell] with one widget per branch in
+  /// [branches]. The length of [branches] must equal `shell.branchCount`. Use
+  /// this when you want to hold the branch routers yourself; otherwise prefer
+  /// [KaiselBranchedShell.specs], which wires them for you.
   const KaiselBranchedShell({
     super.key,
-    required this.shell,
-    required this.branches,
+    required BranchedShellRouter this.shell,
+    required List<Widget> this.branches,
     required this.chromeBuilder,
-  });
+  }) : specs = null,
+       initialBranch = 0;
 
-  /// The shell's state aggregator. Held externally so the caller can
-  /// drive `switchTo` from elsewhere and listen for changes.
-  final BranchedShellRouter shell;
+  /// Create a branched shell from declarative [branches] — one
+  /// [KaiselBranchSpec] per branch. The shell creates, owns, and disposes the
+  /// per-branch routers for you, so you never construct a [KaiselRouter]; each
+  /// branch's stack still survives tab switches. Navigate inside a branch with
+  /// `context.push(...)`, and switch tabs with `context.shell()`.
+  const KaiselBranchedShell.specs({
+    super.key,
+    required List<KaiselBranchSpec> branches,
+    required this.chromeBuilder,
+    this.initialBranch = 0,
+  }) : specs = branches,
+       shell = null,
+       branches = null;
 
-  /// One widget per branch, in the same order as `shell.branches`.
-  /// Each entry is typically a [KaiselBranch] typed to its branch's
-  /// route subtype.
-  final List<Widget> branches;
+  /// The externally-held aggregator (explicit mode), or `null` in specs mode.
+  final BranchedShellRouter? shell;
+
+  /// One widget per branch (explicit mode), or `null` in specs mode.
+  final List<Widget>? branches;
+
+  /// Declarative branches (specs mode), or `null` in explicit mode.
+  final List<KaiselBranchSpec>? specs;
+
+  /// The branch shown first (specs mode).
+  final int initialBranch;
 
   /// Builds the chrome (scaffold, bottom nav, etc.) around the active
   /// branch's content.
@@ -300,18 +395,48 @@ class KaiselBranchedShell extends StatefulWidget {
 }
 
 class _KaiselBranchedShellState extends State<KaiselBranchedShell> {
+  // The effective aggregator and branch widgets. In specs mode these are
+  // created and owned here; in explicit mode they mirror the widget's fields.
+  late BranchedShellRouter _shell;
+  late List<Widget> _branches;
+
+  // Routers this state created (specs mode) and must dispose. Null when the
+  // caller owns the shell (explicit mode).
+  List<KaiselRouter<KaiselRoute>>? _ownedRouters;
+
+  KaiselNestedHost? _host;
+
   @override
   void initState() {
     super.initState();
+    switch ((widget.specs, widget.shell)) {
+      case (final specs?, _):
+        final routers = [for (final spec in specs) spec.createRouter()];
+        _shell = BranchedShellRouter(
+          branches: routers,
+          initialBranch: widget.initialBranch,
+        );
+        _branches = [
+          for (var i = 0; i < specs.length; i++)
+            specs[i].buildBranch(routers[i]),
+        ];
+        _ownedRouters = routers;
+      case (_, final shell?):
+        _shell = shell;
+        _branches = widget.branches ?? const [];
+        _ownedRouters = null;
+      case _:
+        throw StateError(
+          'KaiselBranchedShell needs either specs or shell + branches.',
+        );
+    }
     assert(
-      widget.shell.branchCount == widget.branches.length,
-      'KaiselBranchedShell: shell has ${widget.shell.branchCount} branches '
-      'but ${widget.branches.length} branch widgets were provided.',
+      _shell.branchCount == _branches.length,
+      'KaiselBranchedShell: shell has ${_shell.branchCount} branches '
+      'but ${_branches.length} branch widgets were provided.',
     );
-    widget.shell.addListener(_onChange);
+    _shell.addListener(_onChange);
   }
-
-  KaiselNestedHost? _host;
 
   void _onChange() {
     if (mounted) setState(() {});
@@ -322,27 +447,39 @@ class _KaiselBranchedShellState extends State<KaiselBranchedShell> {
     super.didChangeDependencies();
     final host = KaiselNestedHostScope.maybeOf(context);
     if (!identical(host, _host)) {
-      _host?.unregisterNested(widget.shell);
+      _host?.unregisterNested(_shell);
       _host = host;
-      _host?.registerNested(widget.shell);
+      _host?.registerNested(_shell);
     }
   }
 
   @override
   void didUpdateWidget(KaiselBranchedShell oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (!identical(oldWidget.shell, widget.shell)) {
-      oldWidget.shell.removeListener(_onChange);
-      widget.shell.addListener(_onChange);
-      _host?.unregisterNested(oldWidget.shell);
-      _host?.registerNested(widget.shell);
+    // Specs mode owns its shell for the State's lifetime; only explicit mode
+    // can swap an external shell instance.
+    if (_ownedRouters != null) return;
+    final newShell = widget.shell;
+    if (newShell != null && !identical(oldWidget.shell, newShell)) {
+      _shell.removeListener(_onChange);
+      _host?.unregisterNested(_shell);
+      _shell = newShell;
+      _branches = widget.branches ?? const [];
+      _shell.addListener(_onChange);
+      _host?.registerNested(_shell);
     }
   }
 
   @override
   void dispose() {
-    _host?.unregisterNested(widget.shell);
-    widget.shell.removeListener(_onChange);
+    _host?.unregisterNested(_shell);
+    _shell.removeListener(_onChange);
+    if (_ownedRouters case final routers?) {
+      _shell.dispose();
+      for (final router in routers) {
+        router.dispose();
+      }
+    }
     super.dispose();
   }
 
@@ -352,30 +489,30 @@ class _KaiselBranchedShellState extends State<KaiselBranchedShell> {
       // canPop = true when the active branch is at root — let the
       // parent router pop the shell itself. canPop = false otherwise
       // — we handle the back by popping within the branch.
-      canPop: !widget.shell.currentCanPop,
+      canPop: !_shell.currentCanPop,
       onPopInvokedWithResult: (didPop, _) {
         if (didPop) return;
-        if (widget.shell.currentCanPop) {
-          widget.shell.popCurrent();
+        if (_shell.currentCanPop) {
+          _shell.popCurrent();
         }
       },
       child: BranchedShellScope(
-        shell: widget.shell,
+        shell: _shell,
         child: KaiselShellScope(
-          controller: widget.shell,
+          controller: _shell,
           child: ShellChromeScope(
             accessorHint: 'context.branchedShell()',
             child: Builder(
               builder: (context) {
                 final branchContent = IndexedStack(
-                  index: widget.shell.activeBranch,
-                  children: widget.branches,
+                  index: _shell.activeBranch,
+                  children: _branches,
                 );
                 return widget.chromeBuilder(
                   context,
-                  widget.shell.activeBranch,
+                  _shell.activeBranch,
                   branchContent,
-                  widget.shell.switchTo,
+                  _shell.switchTo,
                 );
               },
             ),

--- a/packages/kaisel/lib/src/kaisel_branched_shell.dart
+++ b/packages/kaisel/lib/src/kaisel_branched_shell.dart
@@ -300,8 +300,11 @@ class KaiselBranchSpec<R extends KaiselRoute> {
           pageWrapper: pageWrapper,
           scope: scope,
         );
+      // Unreachable: both constructors set exactly one builder.
+      // coverage:ignore-start
       case _:
         throw StateError('KaiselBranchSpec has no builder.');
+      // coverage:ignore-end
     }
   }
 }
@@ -450,10 +453,13 @@ class _KaiselBranchedShellState extends State<KaiselBranchedShell> {
         _shell = shell;
         _branches = widget.branches ?? const [];
         _ownedRouters = null;
+      // Unreachable: both constructors set exactly one of specs / shell.
+      // coverage:ignore-start
       case _:
         throw StateError(
           'KaiselBranchedShell needs either specs or shell + branches.',
         );
+      // coverage:ignore-end
     }
     assert(
       _shell.branchCount == _branches.length,

--- a/packages/kaisel/lib/src/kaisel_branched_shell.dart
+++ b/packages/kaisel/lib/src/kaisel_branched_shell.dart
@@ -345,8 +345,8 @@ typedef KaiselBranchedShellChromeBuilder =
 /// ```
 ///
 /// Inside a branch screen, `context.router<BranchR>()` resolves to that
-/// branch's typed router; `context.branchedShell()` resolves to the
-/// enclosing [BranchedShellRouter] for `switchTo` etc.
+/// branch's typed router; `context.shell()` resolves to the enclosing shell
+/// controller for `switchTo`, `activeBranch`, `current`, etc.
 class KaiselBranchedShell extends StatefulWidget {
   /// Create a branched shell driven by [shell] with one widget per branch in
   /// [branches]. The length of [branches] must equal `shell.branchCount`. Use
@@ -496,71 +496,25 @@ class _KaiselBranchedShellState extends State<KaiselBranchedShell> {
           _shell.popCurrent();
         }
       },
-      child: BranchedShellScope(
-        shell: _shell,
-        child: KaiselShellScope(
-          controller: _shell,
-          child: ShellChromeScope(
-            accessorHint: 'context.branchedShell()',
-            child: Builder(
-              builder: (context) {
-                final branchContent = IndexedStack(
-                  index: _shell.activeBranch,
-                  children: _branches,
-                );
-                return widget.chromeBuilder(
-                  context,
-                  _shell.activeBranch,
-                  branchContent,
-                  _shell.switchTo,
-                );
-              },
-            ),
+      child: KaiselShellScope(
+        controller: _shell,
+        child: ShellChromeScope(
+          child: Builder(
+            builder: (context) {
+              final branchContent = IndexedStack(
+                index: _shell.activeBranch,
+                children: _branches,
+              );
+              return widget.chromeBuilder(
+                context,
+                _shell.activeBranch,
+                branchContent,
+                _shell.switchTo,
+              );
+            },
           ),
         ),
       ),
     );
   }
-}
-
-/// Inherited widget exposing the [BranchedShellRouter] to descendants.
-///
-/// Look up via `context.branchedShell()`.
-class BranchedShellScope extends InheritedWidget {
-  /// Create a scope around [child] exposing [shell].
-  const BranchedShellScope({
-    super.key,
-    required this.shell,
-    required super.child,
-  });
-
-  /// The shell exposed at this scope.
-  final BranchedShellRouter shell;
-
-  /// Look up the nearest [BranchedShellScope]. Throws if none is found.
-  static BranchedShellScope of(BuildContext context) {
-    final scope = maybeOf(context);
-    if (scope == null) {
-      throw FlutterError(
-        'BranchedShellScope not found in widget tree.\n'
-        'Ensure the calling widget is inside a KaiselBranchedShell.',
-      );
-    }
-    return scope;
-  }
-
-  /// Like [of], but returns `null` if no scope is found.
-  static BranchedShellScope? maybeOf(BuildContext context) =>
-      context.dependOnInheritedWidgetOfExactType<BranchedShellScope>();
-
-  @override
-  bool updateShouldNotify(BranchedShellScope old) =>
-      !identical(old.shell, shell);
-}
-
-/// Convenience accessor for the enclosing [BranchedShellRouter].
-extension KaiselBranchedShellContextX on BuildContext {
-  /// The enclosing branched shell. Use this to switch tabs
-  /// programmatically: `context.branchedShell().switchTo(2)`.
-  BranchedShellRouter branchedShell() => BranchedShellScope.of(this).shell;
 }

--- a/packages/kaisel/lib/src/kaisel_branched_shell.dart
+++ b/packages/kaisel/lib/src/kaisel_branched_shell.dart
@@ -316,6 +316,23 @@ typedef KaiselBranchedShellChromeBuilder =
       void Function(int branch) switchBranch,
     );
 
+/// Signature for overriding how a [KaiselBranchedShell] lays its branches out —
+/// given the active branch index, the per-branch widgets (in branch order), and
+/// the tab switcher.
+///
+/// Return whatever container suits your UX: a [PageView] for swipeable tabs, a
+/// custom animated switcher, etc. When omitted, the shell uses an [IndexedStack]
+/// that keeps every branch mounted so per-branch state survives tab switches —
+/// if you replace it, preserving that state becomes your responsibility (e.g. a
+/// `PageView` with `AutomaticKeepAliveClientMixin` on its children).
+typedef KaiselBranchContentBuilder =
+    Widget Function(
+      BuildContext context,
+      int activeBranch,
+      List<Widget> branches,
+      void Function(int branch) switchBranch,
+    );
+
 /// A bottom-nav shell whose branches have **different** route types.
 ///
 /// Pass a [BranchedShellRouter] and a parallel list of [KaiselBranch]
@@ -357,6 +374,7 @@ class KaiselBranchedShell extends StatefulWidget {
     required BranchedShellRouter this.shell,
     required List<Widget> this.branches,
     required this.chromeBuilder,
+    this.branchContentBuilder,
   }) : specs = null,
        initialBranch = 0;
 
@@ -370,6 +388,7 @@ class KaiselBranchedShell extends StatefulWidget {
     required List<KaiselBranchSpec> branches,
     required this.chromeBuilder,
     this.initialBranch = 0,
+    this.branchContentBuilder,
   }) : specs = branches,
        shell = null,
        branches = null;
@@ -389,6 +408,12 @@ class KaiselBranchedShell extends StatefulWidget {
   /// Builds the chrome (scaffold, bottom nav, etc.) around the active
   /// branch's content.
   final KaiselBranchedShellChromeBuilder chromeBuilder;
+
+  /// Optional override for how the branches are laid out. When `null`, the
+  /// shell uses an [IndexedStack] (all branches mounted, state preserved). Pass
+  /// one to use a [PageView] or any other container — see
+  /// [KaiselBranchContentBuilder].
+  final KaiselBranchContentBuilder? branchContentBuilder;
 
   @override
   State<KaiselBranchedShell> createState() => _KaiselBranchedShellState();
@@ -501,10 +526,14 @@ class _KaiselBranchedShellState extends State<KaiselBranchedShell> {
         child: ShellChromeScope(
           child: Builder(
             builder: (context) {
-              final branchContent = IndexedStack(
-                index: _shell.activeBranch,
-                children: _branches,
-              );
+              final branchContent =
+                  widget.branchContentBuilder?.call(
+                    context,
+                    _shell.activeBranch,
+                    _branches,
+                    _shell.switchTo,
+                  ) ??
+                  IndexedStack(index: _shell.activeBranch, children: _branches);
               return widget.chromeBuilder(
                 context,
                 _shell.activeBranch,

--- a/packages/kaisel/lib/src/kaisel_router_config.dart
+++ b/packages/kaisel/lib/src/kaisel_router_config.dart
@@ -1,0 +1,109 @@
+import 'package:flutter/widgets.dart';
+import 'package:kaisel_core/kaisel_core.dart';
+
+import 'kaisel_page_wrapper.dart';
+import 'kaisel_route_information_parser.dart';
+import 'kaisel_router_delegate.dart';
+
+/// A ready-made [RouterConfig] that bundles a [KaiselRouter] and a
+/// [KaiselRouterDelegate] — plus a URL parser and platform provider when you
+/// supply a [KaiselConfigCodec] — into the single object that
+/// `MaterialApp.router(routerConfig:)` expects. The same shape go_router uses.
+///
+/// This is the convenience layer over the explicit pieces: you keep your own
+/// `MaterialApp` (theme, localizations, …), and the router plumbing collapses
+/// to one value:
+///
+/// ```dart
+/// final _config = KaiselRouterConfig<AppRoute>(
+///   initial: const Home(),
+///   builder: (context, route) => switch (route) {
+///     Home() => const HomeScreen(),
+///     ProductDetail(:final id) => ProductDetailScreen(id: id),
+///   },
+/// );
+///
+/// // in build:
+/// MaterialApp.router(routerConfig: _config, theme: myTheme);
+/// ```
+///
+/// Omit [codec] for a URL-less app (the config runs delegate-only). Pass a
+/// [codec] (and optional [fallback]) for a URL-addressable one; the parser and
+/// a [PlatformRouteInformationProvider] are wired for you.
+///
+/// Hold it as a top-level `final` for an app-lifetime router — no disposal
+/// needed, exactly like `final _router = GoRouter(...)`. Call [dispose] only if
+/// you own its lifecycle in a [State].
+class KaiselRouterConfig<R extends KaiselRoute>
+    extends RouterConfig<KaiselConfig<R>> {
+  KaiselRouterConfig._({
+    required this.router,
+    required KaiselRouterDelegate<R> delegate,
+    required RouteInformationParser<KaiselConfig<R>>? parser,
+    required RouteInformationProvider? provider,
+  }) : _delegate = delegate,
+       _provider = provider,
+       super(
+         routerDelegate: delegate,
+         routeInformationParser: parser,
+         routeInformationProvider: provider,
+         backButtonDispatcher: RootBackButtonDispatcher(),
+       );
+
+  /// Assemble a config from the parts you actually care about.
+  factory KaiselRouterConfig({
+    required R initial,
+    required KaiselPageBuilder<R> builder,
+    List<KaiselGuard<R>> guards = const [],
+    KaiselPageWrapper<R>? pageWrapper,
+    KaiselModalBuilder? modalBuilder,
+    KaiselConfigCodec<R>? codec,
+    List<R>? fallback,
+  }) {
+    final router = KaiselRouter<R>(initial: initial, guards: guards);
+    final delegate = KaiselRouterDelegate<R>(
+      router: router,
+      builder: builder,
+      pageWrapper: pageWrapper,
+      modalBuilder: modalBuilder,
+    );
+
+    RouteInformationParser<KaiselConfig<R>>? parser;
+    RouteInformationProvider? provider;
+    if (codec case final codec?) {
+      parser = KaiselRouteInformationParser<R>(
+        codec: codec,
+        fallback: fallback ?? [initial],
+      );
+      provider = PlatformRouteInformationProvider(
+        initialRouteInformation: RouteInformation(
+          uri: Uri.parse(
+            WidgetsBinding.instance.platformDispatcher.defaultRouteName,
+          ),
+        ),
+      );
+    }
+
+    return KaiselRouterConfig._(
+      router: router,
+      delegate: delegate,
+      parser: parser,
+      provider: provider,
+    );
+  }
+
+  /// The bundled router, for imperative navigation outside the widget tree.
+  final KaiselRouter<R> router;
+
+  final KaiselRouterDelegate<R> _delegate;
+  final RouteInformationProvider? _provider;
+
+  /// Dispose the bundled router, delegate, and (if any) provider. Only needed
+  /// when you don't keep the config for the app's lifetime.
+  void dispose() {
+    _delegate.dispose();
+    router.dispose();
+    final provider = _provider;
+    if (provider is PlatformRouteInformationProvider) provider.dispose();
+  }
+}

--- a/packages/kaisel/lib/src/kaisel_scope.dart
+++ b/packages/kaisel/lib/src/kaisel_scope.dart
@@ -56,27 +56,24 @@ class RouterScope<R extends KaiselRoute> extends InheritedWidget {
   static RouterScope<R> of<R extends KaiselRoute>(BuildContext context) {
     final scope = maybeOf<R>(context);
     if (scope == null) {
-      final chrome = ShellChromeScope.maybeOf(context);
-      switch (chrome) {
-        case final chrome?:
-          throw FlutterError(
-            'RouterScope<$R> not found above this context.\n'
-            'You are inside a shell chromeBuilder, where each branch installs '
-            'its RouterScope BELOW the chrome — so context.router<$R>() cannot '
-            'resolve a branch router from here.\n'
-            'Use ${chrome.accessorHint} to drive the shell (or the activeBranch '
-            '/ switchBranch arguments), or context.router() with your app root '
-            'route type for the main router.',
-          );
-        case _:
-          throw FlutterError(
-            'RouterScope<$R> not found above this context.\n'
-            'context.router<$R>() walks up the tree for the nearest '
-            'RouterScope<$R>, installed at the app root, inside shell branch '
-            'screens, and inside modal flows. Ensure this widget is mounted under '
-            'a KaiselRouterDelegate<$R> (or the appropriate branch / flow).',
-          );
+      if (ShellChromeScope.maybeOf(context) != null) {
+        throw FlutterError(
+          'RouterScope<$R> not found above this context.\n'
+          'You are inside a shell chromeBuilder, where each branch installs '
+          'its RouterScope BELOW the chrome — so context.router<$R>() cannot '
+          'resolve a branch router from here.\n'
+          'Use context.shell() to drive the shell (or the activeBranch / '
+          'switchBranch arguments), or context.router() with your app root '
+          'route type for the main router.',
+        );
       }
+      throw FlutterError(
+        'RouterScope<$R> not found above this context.\n'
+        'context.router<$R>() walks up the tree for the nearest '
+        'RouterScope<$R>, installed at the app root, inside shell branch '
+        'screens, and inside modal flows. Ensure this widget is mounted under '
+        'a KaiselRouterDelegate<$R> (or the appropriate branch / flow).',
+      );
     }
     return scope;
   }
@@ -94,19 +91,11 @@ class RouterScope<R extends KaiselRoute> extends InheritedWidget {
 ///
 /// Each branch installs its [RouterScope] *below* the chrome, so a
 /// `context.router<R>()` call from the chrome can't resolve a branch router.
-/// This marker lets [RouterScope.of] detect that case and point at the shell's
-/// own accessor ([accessorHint]) instead of a generic "not found".
+/// This marker lets [RouterScope.of] detect that case and point at
+/// `context.shell()` instead of a generic "not found".
 class ShellChromeScope extends InheritedWidget {
-  /// Create a chrome marker around [child] advertising [accessorHint].
-  const ShellChromeScope({
-    super.key,
-    required this.accessorHint,
-    required super.child,
-  });
-
-  /// The accessor to suggest in the error — e.g. `context.branchedShell()`
-  /// or `context.shellRouter<R>()`.
-  final String accessorHint;
+  /// Create a chrome marker around [child].
+  const ShellChromeScope({super.key, required super.child});
 
   /// The nearest enclosing chrome marker, or `null`. Uses a non-dependent
   /// lookup — it is only consulted while composing an error message.
@@ -114,8 +103,7 @@ class ShellChromeScope extends InheritedWidget {
       context.getInheritedWidgetOfExactType<ShellChromeScope>();
 
   @override
-  bool updateShouldNotify(ShellChromeScope old) =>
-      old.accessorHint != accessorHint;
+  bool updateShouldNotify(ShellChromeScope old) => false;
 }
 
 /// Unified router accessors. `context.router<R>()` resolves to the

--- a/packages/kaisel/lib/src/kaisel_scope.dart
+++ b/packages/kaisel/lib/src/kaisel_scope.dart
@@ -23,6 +23,32 @@ class RouterScope<R extends KaiselRoute> extends InheritedWidget {
   /// The router in effect at this scope.
   final KaiselRouter<R> router;
 
+  /// Whether this scope's router can take [route] — i.e. `route is R`.
+  ///
+  /// Works through a non-generic view because Dart reifies `R`: even when
+  /// this scope is held as `RouterScope<KaiselRoute>`, the check runs against
+  /// the instance's real route type.
+  bool accepts(KaiselRoute route) => route is R;
+
+  /// Type-erased navigation used by the `context.*` helpers, which select the
+  /// target scope via [accepts] first, so each cast to `R` is sound.
+  Future<void> pushRoute(KaiselRoute route) => router.push(route as R);
+
+  /// Type-erased [KaiselRouter.replaceTop]; see [pushRoute].
+  Future<void> replaceTopRoute(KaiselRoute route) =>
+      router.replaceTop(route as R);
+
+  /// Type-erased [KaiselRouter.pushOrReplaceTop]; see [pushRoute].
+  Future<void> pushOrReplaceTopRoute(KaiselRoute route) =>
+      router.pushOrReplaceTop(route as R);
+
+  /// Type-erased [KaiselRouter.set]; see [pushRoute].
+  Future<void> setRoutes(List<KaiselRoute> routes) =>
+      router.set(routes.cast<R>());
+
+  /// Run a modal [flow] on this scope's router; see [pushRoute].
+  Future<T?> runFlow<T>(KaiselModalRoute<T> flow) => router.run<T>(flow);
+
   /// The nearest enclosing [RouterScope] of route type [R].
   ///
   /// Throws a [FlutterError] if none is found. Use [maybeOf] for
@@ -114,6 +140,149 @@ extension KaiselRouterContextX on BuildContext {
 
   /// Dismiss the active modal flow with `null`.
   void dismissFlow() => FlowScope.of(this)._complete(null);
+}
+
+/// Terse, go_router-style navigation on `BuildContext`.
+///
+/// Each verb resolves the target router by walking up the tree for the nearest
+/// [RouterScope] whose route type the argument belongs to ([RouterScope.accepts]),
+/// then forwards. So `context.push(const ProductDetail('42'))` finds the router
+/// for the `ProductDetail` family without you naming it. The argument stays a
+/// typed route, so you keep autocomplete and refactors; what you trade vs.
+/// `context.router<R>().push(...)` is the *compile-time* check that the route
+/// belongs to that router — here a wrong-family route throws at runtime instead.
+/// Reach for `context.router<R>()` when you want that check back.
+///
+/// The lookup uses [BuildContext.visitAncestorElements] (no dependency is
+/// created) because these are actions, not build-time reads.
+extension KaiselContextNavigation on BuildContext {
+  /// Push [route] onto the nearest router that accepts it.
+  Future<void> push(KaiselRoute route) =>
+      _scopeForRoute(route).pushRoute(route);
+
+  /// Pop the nearest router. Returns `false` if it was already at root.
+  Future<bool> pop() => _nearestRouterScope().router.pop();
+
+  /// Replace the top of the nearest router that accepts [route].
+  Future<void> replaceTop(KaiselRoute route) =>
+      _scopeForRoute(route).replaceTopRoute(route);
+
+  /// Push, or replace the top if it's the same type, on the nearest accepting
+  /// router.
+  Future<void> pushOrReplaceTop(KaiselRoute route) =>
+      _scopeForRoute(route).pushOrReplaceTopRoute(route);
+
+  /// Replace the whole stack of the nearest router that accepts the routes.
+  Future<void> set(List<KaiselRoute> routes) =>
+      _scopeForRoute(routes.first).setRoutes(routes);
+
+  /// Open [flow] as a modal on the nearest router that accepts it, awaiting
+  /// its typed result.
+  Future<T?> run<T>(KaiselModalRoute<T> flow) =>
+      _scopeForRoute(flow).runFlow<T>(flow);
+
+  /// The nearest [RouterScope] whose router accepts [route]. Throws a
+  /// [FlutterError] if none does.
+  RouterScope _scopeForRoute(KaiselRoute route) {
+    RouterScope? found;
+    visitAncestorElements((element) {
+      final widget = element.widget;
+      if (widget is RouterScope && widget.accepts(route)) {
+        found = widget;
+        return false;
+      }
+      return true;
+    });
+    switch (found) {
+      case final scope?:
+        return scope;
+      case _:
+        throw FlutterError(
+          'No KaiselRouter above this context accepts a ${route.runtimeType}.\n'
+          'context.push / replaceTop / pushOrReplaceTop resolve the nearest '
+          'router whose route type the argument belongs to. Ensure this widget '
+          'is under a KaiselRouterDelegate (or branch / flow) whose route type '
+          'is a supertype of ${route.runtimeType}.',
+        );
+    }
+  }
+
+  /// The nearest [RouterScope] regardless of route type. Throws if none.
+  RouterScope _nearestRouterScope() {
+    RouterScope? found;
+    visitAncestorElements((element) {
+      if (element.widget is RouterScope) {
+        found = element.widget as RouterScope;
+        return false;
+      }
+      return true;
+    });
+    switch (found) {
+      case final scope?:
+        return scope;
+      case _:
+        throw FlutterError(
+          'No KaiselRouter found above this context for context.pop().',
+        );
+    }
+  }
+}
+
+/// The common control surface of a kaisel shell. Both `KaiselBranchedShell`
+/// (via `BranchedShellRouter`) and `KaiselShell` (via `ShellRouter`) expose it,
+/// so descendants can switch tabs and read the active branch through one
+/// accessor — `context.shell()` — without knowing which shell flavour is above
+/// them, or its route type.
+abstract interface class KaiselShellController implements Listenable {
+  /// Index of the currently selected branch.
+  int get activeBranch;
+
+  /// Number of branches in the shell.
+  int get branchCount;
+
+  /// Select a different branch. No-op if [branch] is already active.
+  void switchTo(int branch);
+}
+
+/// Inherited widget exposing the nearest [KaiselShellController]. Installed by
+/// `KaiselBranchedShell` and `KaiselShell`; reached via `context.shell()`.
+class KaiselShellScope extends InheritedWidget {
+  /// Create a scope around [child] exposing [controller].
+  const KaiselShellScope({
+    super.key,
+    required this.controller,
+    required super.child,
+  });
+
+  /// The shell controller in effect at this scope.
+  final KaiselShellController controller;
+
+  /// The nearest enclosing controller, or `null`.
+  static KaiselShellController? maybeOf(BuildContext context) => context
+      .dependOnInheritedWidgetOfExactType<KaiselShellScope>()
+      ?.controller;
+
+  @override
+  bool updateShouldNotify(KaiselShellScope old) =>
+      !identical(old.controller, controller);
+}
+
+/// One accessor for switching tabs from anywhere inside any shell.
+extension KaiselShellContextX on BuildContext {
+  /// The nearest [KaiselShellController] — branched or homogeneous. Throws a
+  /// [FlutterError] if there's no shell above this context.
+  KaiselShellController shell() {
+    final controller = KaiselShellScope.maybeOf(this);
+    switch (controller) {
+      case final controller?:
+        return controller;
+      case _:
+        throw FlutterError(
+          'context.shell() found no KaiselShell / KaiselBranchedShell above '
+          'this context.',
+        );
+    }
+  }
 }
 
 /// Inherited widget that marks a subtree as living inside an active

--- a/packages/kaisel/lib/src/kaisel_scope.dart
+++ b/packages/kaisel/lib/src/kaisel_scope.dart
@@ -240,6 +240,12 @@ abstract interface class KaiselShellController implements Listenable {
   /// Number of branches in the shell.
   int get branchCount;
 
+  /// The active branch's router, type-erased. Lets shell chrome read the
+  /// active stack (e.g. for a breadcrumb) and pop it, without holding a
+  /// reference to the per-branch router. The controller notifies on both
+  /// branch switches and active-stack changes.
+  KaiselNavigator get current;
+
   /// Select a different branch. No-op if [branch] is already active.
   void switchTo(int branch);
 }

--- a/packages/kaisel/lib/src/kaisel_shell.dart
+++ b/packages/kaisel/lib/src/kaisel_shell.dart
@@ -14,7 +14,8 @@ import 'kaisel_scope.dart';
 /// Branches share the route type [R]; you constrain "what's valid on
 /// which tab" through your pattern-matched [KaiselPageBuilder] and your
 /// own discipline. For per-branch typed routes, see [KaiselBranchedShell].
-class ShellRouter<R extends KaiselRoute> extends ChangeNotifier {
+class ShellRouter<R extends KaiselRoute> extends ChangeNotifier
+    implements KaiselShellController {
   /// Create a shell with one router per [branchInitials].
   ShellRouter({
     required List<R> branchInitials,
@@ -45,15 +46,18 @@ class ShellRouter<R extends KaiselRoute> extends ChangeNotifier {
   List<KaiselRouter<R>> get branches => List.unmodifiable(_branches);
 
   /// Index of the currently selected branch.
+  @override
   int get activeBranch => _activeBranch;
 
   /// The router for the currently selected branch.
   KaiselRouter<R> get current => _branches[_activeBranch];
 
   /// Number of branches.
+  @override
   int get branchCount => _branches.length;
 
   /// Select a different branch. No-op if [branch] is already active.
+  @override
   void switchTo(int branch) {
     if (branch < 0 || branch >= _branches.length) {
       throw RangeError.range(branch, 0, _branches.length - 1, 'branch');
@@ -212,24 +216,27 @@ class _KaiselShellState<R extends KaiselRoute> extends State<KaiselShell<R>> {
       },
       child: ShellScope<R>(
         shellRouter: _shell,
-        child: ShellChromeScope(
-          accessorHint: 'context.shellRouter<$R>()',
-          child: Builder(
-            builder: (context) {
-              final branchContent = IndexedStack(
-                index: _shell.activeBranch,
-                children: [
-                  for (var i = 0; i < _shell.branchCount; i++)
-                    _buildBranch(context, i),
-                ],
-              );
-              return widget.chromeBuilder(
-                context,
-                _shell.activeBranch,
-                branchContent,
-                _shell.switchTo,
-              );
-            },
+        child: KaiselShellScope(
+          controller: _shell,
+          child: ShellChromeScope(
+            accessorHint: 'context.shellRouter<$R>()',
+            child: Builder(
+              builder: (context) {
+                final branchContent = IndexedStack(
+                  index: _shell.activeBranch,
+                  children: [
+                    for (var i = 0; i < _shell.branchCount; i++)
+                      _buildBranch(context, i),
+                  ],
+                );
+                return widget.chromeBuilder(
+                  context,
+                  _shell.activeBranch,
+                  branchContent,
+                  _shell.switchTo,
+                );
+              },
+            ),
           ),
         ),
       ),

--- a/packages/kaisel/lib/src/kaisel_shell.dart
+++ b/packages/kaisel/lib/src/kaisel_shell.dart
@@ -50,6 +50,7 @@ class ShellRouter<R extends KaiselRoute> extends ChangeNotifier
   int get activeBranch => _activeBranch;
 
   /// The router for the currently selected branch.
+  @override
   KaiselRouter<R> get current => _branches[_activeBranch];
 
   /// Number of branches.

--- a/packages/kaisel/lib/src/kaisel_shell.dart
+++ b/packages/kaisel/lib/src/kaisel_shell.dart
@@ -103,8 +103,8 @@ typedef KaiselBranchScope =
 /// Place a `KaiselShell` in your top-level builder as the screen for the
 /// "main app" route variant. Inside any branch screen, get the branch's
 /// router via `context.router<AppRoute>()` (which resolves to the
-/// active branch's router when inside a shell) and the shell router
-/// via `context.shellRouter<AppRoute>()`.
+/// active branch's router when inside a shell) and the shell controller
+/// via `context.shell()`.
 class KaiselShell<R extends KaiselRoute> extends StatefulWidget {
   /// Create a shell with [branchInitials.length] branches using a
   /// simple per-route page builder.
@@ -215,29 +215,25 @@ class _KaiselShellState<R extends KaiselRoute> extends State<KaiselShell<R>> {
           activeRouter.pop();
         }
       },
-      child: ShellScope<R>(
-        shellRouter: _shell,
-        child: KaiselShellScope(
-          controller: _shell,
-          child: ShellChromeScope(
-            accessorHint: 'context.shellRouter<$R>()',
-            child: Builder(
-              builder: (context) {
-                final branchContent = IndexedStack(
-                  index: _shell.activeBranch,
-                  children: [
-                    for (var i = 0; i < _shell.branchCount; i++)
-                      _buildBranch(context, i),
-                  ],
-                );
-                return widget.chromeBuilder(
-                  context,
-                  _shell.activeBranch,
-                  branchContent,
-                  _shell.switchTo,
-                );
-              },
-            ),
+      child: KaiselShellScope(
+        controller: _shell,
+        child: ShellChromeScope(
+          child: Builder(
+            builder: (context) {
+              final branchContent = IndexedStack(
+                index: _shell.activeBranch,
+                children: [
+                  for (var i = 0; i < _shell.branchCount; i++)
+                    _buildBranch(context, i),
+                ],
+              );
+              return widget.chromeBuilder(
+                context,
+                _shell.activeBranch,
+                branchContent,
+                _shell.switchTo,
+              );
+            },
           ),
         ),
       ),
@@ -261,65 +257,4 @@ class _KaiselShellState<R extends KaiselRoute> extends State<KaiselShell<R>> {
     // inside a branch screen resolves to that branch's router.
     return RouterScope<R>(router: router, child: content);
   }
-}
-
-/// Inherited widget exposing the [ShellRouter] to descendants.
-///
-/// For most navigation, prefer `context.router<R>()` (which resolves to
-/// the active branch's router inside a shell). Use this when you
-/// specifically need to switch branches programmatically:
-/// `context.shellRouter<R>().switchTo(2)`.
-class ShellScope<R extends KaiselRoute> extends InheritedWidget {
-  /// Create a scope around [child] exposing [shellRouter].
-  const ShellScope({
-    super.key,
-    required this.shellRouter,
-    required super.child,
-  });
-
-  /// The shell router exposed at this scope.
-  final ShellRouter<R> shellRouter;
-
-  /// Look up the nearest [ShellScope] of route type [R].
-  ///
-  /// Throws if no scope is found — wrap your screen in a [KaiselShell]
-  /// or use [maybeOf] if absence is expected.
-  static ShellScope<R> of<R extends KaiselRoute>(BuildContext context) {
-    final scope = maybeOf<R>(context);
-    if (scope == null) {
-      throw FlutterError(
-        'ShellScope<$R> not found in widget tree.\n'
-        'Ensure the calling widget is inside a KaiselShell<$R>.',
-      );
-    }
-    return scope;
-  }
-
-  /// Like [of], but returns null instead of throwing.
-  static ShellScope<R>? maybeOf<R extends KaiselRoute>(BuildContext context) =>
-      context.dependOnInheritedWidgetOfExactType<ShellScope<R>>();
-
-  @override
-  bool updateShouldNotify(ShellScope<R> old) =>
-      !identical(old.shellRouter, shellRouter);
-}
-
-/// Convenience accessors for shell-scoped routers.
-///
-/// Prefer `context.router<R>()` for in-branch pushes (it resolves to
-/// the branch router when inside a shell). These accessors are for the
-/// shell-specific operations.
-extension KaiselShellBuildContextX on BuildContext {
-  /// The router for the currently active branch in the enclosing
-  /// [KaiselShell]. Equivalent to `context.router<R>()` when inside a
-  /// shell.
-  ///
-  /// Prefer `context.router<R>()` in new code.
-  KaiselRouter<R> branchRouter<R extends KaiselRoute>() =>
-      ShellScope.of<R>(this).shellRouter.current;
-
-  /// The enclosing [ShellRouter]. Use this to switch tabs
-  /// programmatically.
-  ShellRouter<R> shellRouter<R extends KaiselRoute>() =>
-      ShellScope.of<R>(this).shellRouter;
 }

--- a/packages/kaisel/test/ergonomics_test.dart
+++ b/packages/kaisel/test/ergonomics_test.dart
@@ -202,6 +202,76 @@ void main() {
     });
   });
 
+  group('KaiselBranchedShell.specs', () {
+    testWidgets('wires the routers and preserves branch state across tab '
+        'switches', (tester) async {
+      late BuildContext branch0;
+      late void Function(int) switchTo;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselBranchedShell.specs(
+            // Declarative — no KaiselRouter constructed here.
+            branches: [
+              KaiselBranchSpec<_BranchR>(
+                initial: const _X(),
+                builder: (context, route) => switch (route) {
+                  _X() => Builder(
+                    builder: (c) {
+                      branch0 = c;
+                      return const Text(
+                        'b0-X',
+                        textDirection: TextDirection.ltr,
+                      );
+                    },
+                  ),
+                  _Y() => const Text('b0-Y', textDirection: TextDirection.ltr),
+                },
+              ),
+              KaiselBranchSpec<_R>(
+                initial: const _A(),
+                builder: (context, route) => switch (route) {
+                  _A() => const Text('b1-A', textDirection: TextDirection.ltr),
+                  _B() => const Text('b1-B', textDirection: TextDirection.ltr),
+                  _Flow() => const SizedBox(),
+                },
+              ),
+            ],
+            chromeBuilder: (context, active, content, sb) {
+              switchTo = sb;
+              return content;
+            },
+          ),
+        ),
+      );
+
+      // The shell created the branch routers from the specs.
+      expect(find.text('b0-X'), findsOneWidget);
+
+      // Push into branch 0 via context.push (resolves to the _BranchR router).
+      await branch0.push(const _Y());
+      await tester.pumpAndSettle();
+      expect(find.text('b0-Y'), findsOneWidget);
+
+      // Switch away and back — the branch's stack must survive (the routers
+      // are created once, not rebuilt per switch).
+      switchTo(1);
+      await tester.pumpAndSettle();
+      expect(find.text('b1-A'), findsOneWidget);
+
+      switchTo(0);
+      await tester.pumpAndSettle();
+      expect(
+        find.text('b0-Y'),
+        findsOneWidget,
+        reason: 'branch 0 kept its pushed route',
+      );
+
+      // Tearing the shell down disposes the routers it owns (no errors).
+      await tester.pumpWidget(const SizedBox());
+    });
+  });
+
   group('KaiselRouterConfig', () {
     testWidgets('drives a MaterialApp.router with no manual plumbing', (
       tester,

--- a/packages/kaisel/test/ergonomics_test.dart
+++ b/packages/kaisel/test/ergonomics_test.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kaisel/kaisel.dart';
+
+// Two distinct sealed route families, so the accepts-walk has something to
+// discriminate on.
+sealed class _R extends KaiselRoute {
+  const _R();
+}
+
+final class _A extends _R {
+  const _A();
+}
+
+final class _B extends _R {
+  const _B();
+}
+
+sealed class _BranchR extends KaiselRoute {
+  const _BranchR();
+}
+
+final class _X extends _BranchR {
+  const _X();
+}
+
+final class _Y extends _BranchR {
+  const _Y();
+}
+
+// A modal flow in the _R family, for context.run.
+final class _Flow extends _R implements KaiselModalRoute<bool> {
+  const _Flow();
+}
+
+// Minimal stack codec for the URL test: /a, /b round-trip.
+class _StackCodec extends KaiselStackCodec<_R> {
+  const _StackCodec();
+
+  @override
+  Uri encode(List<_R> stack) =>
+      Uri(pathSegments: [for (final r in stack) _seg(r)]);
+
+  @override
+  List<_R>? decode(Uri uri) {
+    final out = <_R>[];
+    for (final segment in uri.pathSegments) {
+      final route = _route(segment);
+      if (route == null) return null;
+      out.add(route);
+    }
+    return out.isEmpty ? null : out;
+  }
+
+  static String _seg(_R route) => switch (route) {
+    _A() => 'a',
+    _B() => 'b',
+    _ => '_',
+  };
+
+  static _R? _route(String segment) => switch (segment) {
+    'a' => const _A(),
+    'b' => const _B(),
+    _ => null,
+  };
+}
+
+void main() {
+  group('context.* navigation verbs', () {
+    testWidgets('push / pop resolve the nearest router', (tester) async {
+      final router = KaiselRouter<_R>(initial: const _A());
+      addTearDown(router.dispose);
+
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouterScope<_R>(
+            router: router,
+            child: Builder(
+              builder: (c) {
+                ctx = c;
+                return const SizedBox();
+              },
+            ),
+          ),
+        ),
+      );
+
+      await ctx.push(const _B());
+      expect(router.stack, const [_A(), _B()]);
+
+      await ctx.pushOrReplaceTop(const _B());
+      expect(router.stack, const [
+        _A(),
+        _B(),
+      ], reason: 'same type replaces top');
+
+      await ctx.pop();
+      expect(router.stack, const [_A()]);
+    });
+
+    testWidgets('push routes by family — nearest accepting router wins', (
+      tester,
+    ) async {
+      final main = KaiselRouter<_R>(initial: const _A());
+      final branch = KaiselRouter<_BranchR>(initial: const _X());
+      addTearDown(main.dispose);
+      addTearDown(branch.dispose);
+
+      // main scope above, branch scope nearer the leaf.
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouterScope<_R>(
+            router: main,
+            child: RouterScope<_BranchR>(
+              router: branch,
+              child: Builder(
+                builder: (c) {
+                  ctx = c;
+                  return const SizedBox();
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // _Y is a _BranchR → nearest (branch) accepts it.
+      await ctx.push(const _Y());
+      expect(branch.stack, const [_X(), _Y()]);
+      expect(main.stack, const [_A()]);
+
+      // _B is an _R, not a _BranchR → branch rejects, walk up to main.
+      await ctx.push(const _B());
+      expect(main.stack, const [_A(), _B()]);
+      expect(branch.stack, const [_X(), _Y()], reason: 'branch untouched');
+    });
+
+    testWidgets('throws a helpful error when no router accepts the route', (
+      tester,
+    ) async {
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (c) {
+              ctx = c;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      Object? caught;
+      try {
+        await ctx.push(const _A());
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<FlutterError>());
+      expect('$caught', contains('No KaiselRouter above this context accepts'));
+    });
+  });
+
+  group('context.shell()', () {
+    testWidgets('switches branches for a branched shell', (tester) async {
+      final b1 = KaiselRouter<_BranchR>(initial: const _X());
+      final b2 = KaiselRouter<_R>(initial: const _A());
+      final shell = BranchedShellRouter(branches: [b1, b2]);
+      addTearDown(shell.dispose);
+      addTearDown(b1.dispose);
+      addTearDown(b2.dispose);
+
+      late BuildContext chromeCtx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselBranchedShell(
+            shell: shell,
+            branches: [
+              KaiselBranch<_BranchR>(
+                router: b1,
+                pageBuilder: (c, r) => const Scaffold(),
+              ),
+              KaiselBranch<_R>(
+                router: b2,
+                pageBuilder: (c, r) => const Scaffold(),
+              ),
+            ],
+            chromeBuilder: (context, active, content, switchBranch) {
+              chromeCtx = context;
+              return content;
+            },
+          ),
+        ),
+      );
+
+      expect(shell.activeBranch, 0);
+      chromeCtx.shell().switchTo(1);
+      await tester.pump();
+      expect(shell.activeBranch, 1);
+    });
+  });
+
+  group('KaiselRouterConfig', () {
+    testWidgets('drives a MaterialApp.router with no manual plumbing', (
+      tester,
+    ) async {
+      final config = KaiselRouterConfig<_R>(
+        initial: const _A(),
+        builder: (context, route) => switch (route) {
+          _A() => const Text('A', textDirection: TextDirection.ltr),
+          _B() => const Text('B', textDirection: TextDirection.ltr),
+          _Flow() => const SizedBox(),
+        },
+      );
+      addTearDown(config.dispose);
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: config));
+      expect(find.text('A'), findsOneWidget);
+
+      await config.router.push(const _B());
+      await tester.pumpAndSettle();
+      expect(find.text('B'), findsOneWidget);
+    });
+
+    testWidgets('wires the codec so a deep link decodes to the stack', (
+      tester,
+    ) async {
+      // The platform launches the app at /b; the config's parser + provider
+      // should decode it into [_B()].
+      tester.platformDispatcher.defaultRouteNameTestValue = '/b';
+      addTearDown(tester.platformDispatcher.clearDefaultRouteNameTestValue);
+
+      final config = KaiselRouterConfig<_R>(
+        initial: const _A(),
+        codec: const StackToConfigCodec<_R>(_StackCodec()),
+        builder: (context, route) => switch (route) {
+          _A() => const Text('A', textDirection: TextDirection.ltr),
+          _B() => const Text('B', textDirection: TextDirection.ltr),
+          _Flow() => const SizedBox(),
+        },
+      );
+      addTearDown(config.dispose);
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: config));
+      await tester.pumpAndSettle();
+
+      expect(config.routeInformationProvider, isNotNull);
+      expect(config.router.stack, const [_B()]);
+      expect(find.text('B'), findsOneWidget);
+    });
+  });
+
+  group('context.run', () {
+    testWidgets('opens a flow on the nearest accepting router and returns its '
+        'typed result', (tester) async {
+      final main = KaiselRouter<_R>(initial: const _A());
+      final branch = KaiselRouter<_BranchR>(initial: const _X());
+      addTearDown(main.dispose);
+      addTearDown(branch.dispose);
+
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: RouterScope<_R>(
+            router: main,
+            child: RouterScope<_BranchR>(
+              router: branch,
+              child: Builder(
+                builder: (c) {
+                  ctx = c;
+                  return const SizedBox();
+                },
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // _Flow is an _R, not a _BranchR — the walk skips the branch and runs it
+      // on the main router.
+      final result = ctx.run<bool>(const _Flow());
+      expect(branch.activeFlows, isEmpty);
+      expect(main.activeFlows, isNotEmpty);
+
+      main.completeFlow<bool>(true);
+      expect(await result, isTrue);
+    });
+  });
+}

--- a/packages/kaisel/test/ergonomics_test.dart
+++ b/packages/kaisel/test/ergonomics_test.dart
@@ -270,6 +270,44 @@ void main() {
       // Tearing the shell down disposes the routers it owns (no errors).
       await tester.pumpWidget(const SizedBox());
     });
+
+    testWidgets('branchContentBuilder overrides the default IndexedStack', (
+      tester,
+    ) async {
+      var receivedActive = -1;
+      var receivedCount = -1;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselBranchedShell.specs(
+            branches: [
+              KaiselBranchSpec<_BranchR>(
+                initial: const _X(),
+                builder: (context, route) => const Scaffold(),
+              ),
+              KaiselBranchSpec<_R>(
+                initial: const _A(),
+                builder: (context, route) => const Scaffold(),
+              ),
+            ],
+            branchContentBuilder: (context, active, branches, switchBranch) {
+              receivedActive = active;
+              receivedCount = branches.length;
+              // A PageView instead of the default IndexedStack.
+              return PageView(children: branches);
+            },
+            chromeBuilder: (context, active, content, sb) => content,
+          ),
+        ),
+      );
+
+      // The custom builder ran with the shell's active index and branch list,
+      // and a PageView is in the tree — no IndexedStack.
+      expect(receivedActive, 0);
+      expect(receivedCount, 2);
+      expect(find.byType(PageView), findsOneWidget);
+      expect(find.byType(IndexedStack), findsNothing);
+    });
   });
 
   group('KaiselRouterConfig', () {

--- a/packages/kaisel/test/ergonomics_test.dart
+++ b/packages/kaisel/test/ergonomics_test.dart
@@ -97,6 +97,54 @@ void main() {
 
       await ctx.pop();
       expect(router.stack, const [_A()]);
+
+      await ctx.replaceTop(const _B());
+      expect(router.stack, const [_B()], reason: 'replaceTop swaps the top');
+
+      await ctx.set(const [_A(), _B()]);
+      expect(router.stack, const [
+        _A(),
+        _B(),
+      ], reason: 'set replaces the stack');
+    });
+
+    testWidgets('pop throws when no router is in scope', (tester) async {
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (c) {
+              ctx = c;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      Object? caught;
+      try {
+        await ctx.pop();
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<FlutterError>());
+      expect('$caught', contains('context.pop()'));
+    });
+
+    testWidgets('shell() throws when no shell is in scope', (tester) async {
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (c) {
+              ctx = c;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(ctx.shell, throwsA(isA<FlutterError>()));
     });
 
     testWidgets('push routes by family — nearest accepting router wins', (
@@ -394,6 +442,248 @@ void main() {
 
       main.completeFlow<bool>(true);
       expect(await result, isTrue);
+    });
+  });
+
+  group('context.completeFlow / dismissFlow', () {
+    KaiselRouterConfig<_R> flowConfig() => KaiselRouterConfig<_R>(
+      initial: const _A(),
+      builder: (context, route) => switch (route) {
+        _A() => const Text('home', textDirection: TextDirection.ltr),
+        _B() => const Text('B', textDirection: TextDirection.ltr),
+        _Flow() => Builder(
+          builder: (c) => Column(
+            children: [
+              TextButton(
+                onPressed: () => c.completeFlow<bool>(true),
+                child: const Text('confirm'),
+              ),
+              TextButton(onPressed: c.dismissFlow, child: const Text('cancel')),
+            ],
+          ),
+        ),
+      },
+      modalBuilder: (context, flowRoute, flowChild) =>
+          Material(child: flowChild),
+    );
+
+    testWidgets('completeFlow resolves the active flow with its value', (
+      tester,
+    ) async {
+      final config = flowConfig();
+      addTearDown(config.dispose);
+      await tester.pumpWidget(MaterialApp.router(routerConfig: config));
+
+      final result = config.router.run<bool>(const _Flow());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('confirm'));
+      await tester.pumpAndSettle();
+
+      expect(await result, isTrue);
+    });
+
+    testWidgets('dismissFlow resolves the active flow with null', (
+      tester,
+    ) async {
+      final config = flowConfig();
+      addTearDown(config.dispose);
+      await tester.pumpWidget(MaterialApp.router(routerConfig: config));
+
+      final result = config.router.run<bool>(const _Flow());
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('cancel'));
+      await tester.pumpAndSettle();
+
+      expect(await result, isNull);
+    });
+
+    testWidgets('completeFlow outside a flow throws', (tester) async {
+      late BuildContext ctx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (c) {
+              ctx = c;
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(() => ctx.completeFlow<bool>(true), throwsA(isA<FlutterError>()));
+    });
+  });
+
+  group('KaiselBranchedShell internals', () {
+    KaiselBranch<R> branch<R extends KaiselRoute>(
+      KaiselRouter<R> router, {
+      Widget Function(BuildContext, Widget)? scope,
+    }) => KaiselBranch<R>(
+      router: router,
+      pageBuilder: (c, r) => const Scaffold(),
+      scope: scope,
+    );
+
+    test('BranchedShellRouter.branches exposes the navigators', () {
+      final a = KaiselRouter<_BranchR>(initial: const _X());
+      final b = KaiselRouter<_R>(initial: const _A());
+      final shell = BranchedShellRouter(branches: [a, b]);
+      addTearDown(shell.dispose);
+      addTearDown(a.dispose);
+      addTearDown(b.dispose);
+
+      expect(shell.branches, [a, b]);
+      expect(shell.branchCount, 2);
+    });
+
+    testWidgets('asserts the branch-widget count matches the shell', (
+      tester,
+    ) async {
+      final a = KaiselRouter<_BranchR>(initial: const _X());
+      final b = KaiselRouter<_R>(initial: const _A());
+      final shell = BranchedShellRouter(branches: [a, b]);
+      addTearDown(shell.dispose);
+      addTearDown(a.dispose);
+      addTearDown(b.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselBranchedShell(
+            shell: shell,
+            branches: [branch<_BranchR>(a)], // 1 widget for 2 branches
+            chromeBuilder: (c, active, content, sb) => content,
+          ),
+        ),
+      );
+      expect(tester.takeException(), isAssertionError);
+    });
+
+    testWidgets('KaiselBranch scope wraps the branch content', (tester) async {
+      final a = KaiselRouter<_BranchR>(initial: const _X());
+      final b = KaiselRouter<_R>(initial: const _A());
+      final shell = BranchedShellRouter(branches: [a, b]);
+      addTearDown(shell.dispose);
+      addTearDown(a.dispose);
+      addTearDown(b.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselBranchedShell(
+            shell: shell,
+            branches: [
+              branch<_BranchR>(
+                a,
+                scope: (context, child) =>
+                    KeyedSubtree(key: const Key('scoped'), child: child),
+              ),
+              branch<_R>(b),
+            ],
+            chromeBuilder: (c, active, content, sb) => content,
+          ),
+        ),
+      );
+      expect(
+        find.byKey(const Key('scoped'), skipOffstage: false),
+        findsOneWidget,
+      );
+    });
+
+    testWidgets('KaiselBranchSpec.adaptive builds an adaptive branch', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselBranchedShell.specs(
+            branches: [
+              KaiselBranchSpec<_BranchR>.adaptive(
+                initial: const _X(),
+                builder: (context, route, stack) => const KaiselStandalonePage(
+                  Text('adaptive-x', textDirection: TextDirection.ltr),
+                ),
+              ),
+              KaiselBranchSpec<_R>(
+                initial: const _A(),
+                builder: (c, r) => const Scaffold(),
+              ),
+            ],
+            chromeBuilder: (c, active, content, sb) => content,
+          ),
+        ),
+      );
+      expect(find.text('adaptive-x'), findsOneWidget);
+    });
+
+    testWidgets('rewires when the shell instance is swapped', (tester) async {
+      final a1 = KaiselRouter<_BranchR>(initial: const _X());
+      final b1 = KaiselRouter<_R>(initial: const _A());
+      final shell1 = BranchedShellRouter(branches: [a1, b1]);
+      final a2 = KaiselRouter<_BranchR>(initial: const _X());
+      final b2 = KaiselRouter<_R>(initial: const _A());
+      final shell2 = BranchedShellRouter(branches: [a2, b2]);
+      addTearDown(a1.dispose);
+      addTearDown(b1.dispose);
+      addTearDown(shell1.dispose);
+      addTearDown(a2.dispose);
+      addTearDown(b2.dispose);
+      addTearDown(shell2.dispose);
+
+      Widget tree(
+        BranchedShellRouter shell,
+        KaiselRouter<_BranchR> a,
+        KaiselRouter<_R> b,
+      ) => MaterialApp(
+        home: KaiselBranchedShell(
+          shell: shell,
+          branches: [branch<_BranchR>(a), branch<_R>(b)],
+          chromeBuilder: (c, active, content, sb) =>
+              Text('active=$active', textDirection: TextDirection.ltr),
+        ),
+      );
+
+      await tester.pumpWidget(tree(shell1, a1, b1));
+      expect(find.text('active=0'), findsOneWidget);
+
+      shell2.switchTo(1);
+      // Same widget type, new shell instance → didUpdateWidget re-wires to it.
+      await tester.pumpWidget(tree(shell2, a2, b2));
+      await tester.pump();
+      expect(find.text('active=1'), findsOneWidget);
+    });
+
+    testWidgets('back-handler pops the active branch when it has history', (
+      tester,
+    ) async {
+      final a = KaiselRouter<_BranchR>(initial: const _X());
+      final b = KaiselRouter<_R>(initial: const _A());
+      final shell = BranchedShellRouter(branches: [a, b]);
+      addTearDown(shell.dispose);
+      addTearDown(a.dispose);
+      addTearDown(b.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselBranchedShell(
+            shell: shell,
+            branches: [branch<_BranchR>(a), branch<_R>(b)],
+            chromeBuilder: (c, active, content, sb) => content,
+          ),
+        ),
+      );
+
+      await a.push(const _Y());
+      await tester.pumpAndSettle();
+      expect(shell.currentCanPop, isTrue);
+
+      final popScope = tester.widget<PopScope<Object?>>(
+        find.byWidgetPredicate((w) => w is PopScope),
+      );
+      expect(popScope.canPop, isFalse);
+      final onPop = popScope.onPopInvokedWithResult;
+      expect(onPop, isNotNull);
+      onPop?.call(false, null);
+      await tester.pumpAndSettle();
+
+      expect(a.stack.length, 1, reason: 'back popped within the branch');
     });
   });
 }

--- a/packages/kaisel/test/kaisel_branched_shell_test.dart
+++ b/packages/kaisel/test/kaisel_branched_shell_test.dart
@@ -335,7 +335,7 @@ void main() {
   group('Shell chrome router resolution', () {
     testWidgets(
       'context.router<BranchRoute>() in a KaiselBranchedShell chrome points at '
-      'context.branchedShell()',
+      'context.shell()',
       (tester) async {
         final home = KaiselRouter<_HomeRoute>(initial: const _HomeRoot());
         final discover = KaiselRouter<_DiscoverRoute>(
@@ -378,12 +378,12 @@ void main() {
         );
 
         expect(caught, isNotNull);
-        expect(caught?.message, contains('context.branchedShell()'));
+        expect(caught?.message, contains('context.shell()'));
       },
     );
 
     testWidgets('context.router<R>() in a KaiselShell chrome points at '
-        'context.shellRouter<R>()', (tester) async {
+        'context.shell()', (tester) async {
       FlutterError? caught;
       await tester.pumpWidget(
         MaterialApp(
@@ -404,7 +404,7 @@ void main() {
       );
 
       expect(caught, isNotNull);
-      expect(caught?.message, contains('context.shellRouter<'));
+      expect(caught?.message, contains('context.shell()'));
     });
 
     testWidgets(

--- a/packages/kaisel/test/kaisel_shell_test.dart
+++ b/packages/kaisel/test/kaisel_shell_test.dart
@@ -1,0 +1,148 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kaisel/kaisel.dart';
+
+// Homogeneous shell: all branches share one route type.
+sealed class _Tab extends KaiselRoute {
+  const _Tab();
+}
+
+final class _TabA extends _Tab {
+  const _TabA();
+}
+
+final class _TabB extends _Tab {
+  const _TabB();
+}
+
+void main() {
+  group('KaiselShell', () {
+    testWidgets('.adaptive builds branches with an adaptive page builder', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselShell<_Tab>.adaptive(
+            branchInitials: const [_TabA(), _TabB()],
+            pageBuilder: (context, route, stack) => KaiselStandalonePage(
+              Text(
+                route is _TabA ? 'tab-a' : 'tab-b',
+                textDirection: TextDirection.ltr,
+              ),
+            ),
+            chromeBuilder: (context, active, content, switchBranch) => content,
+          ),
+        ),
+      );
+
+      // Branch 0 (_TabA) is active and rendered through the adaptive builder.
+      expect(find.text('tab-a'), findsOneWidget);
+    });
+
+    testWidgets('switchTo rebuilds the chrome with the new active branch', (
+      tester,
+    ) async {
+      late void Function(int) switchBranch;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselShell<_Tab>(
+            branchInitials: const [_TabA(), _TabB()],
+            pageBuilder: (context, route) => const Scaffold(),
+            chromeBuilder: (context, active, content, sb) {
+              switchBranch = sb;
+              return Column(
+                children: [
+                  Text('active=$active', textDirection: TextDirection.ltr),
+                  Expanded(child: content),
+                ],
+              );
+            },
+          ),
+        ),
+      );
+
+      expect(find.text('active=0'), findsOneWidget);
+
+      // Drives ShellRouter.switchTo → notifyListeners → the shell's internal
+      // listener calls setState and the chrome rebuilds.
+      switchBranch(1);
+      await tester.pump();
+      expect(find.text('active=1'), findsOneWidget);
+    });
+
+    testWidgets('back pops within the active branch when it has history', (
+      tester,
+    ) async {
+      late BuildContext branchCtx;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselShell<_Tab>(
+            branchInitials: const [_TabA(), _TabB()],
+            pageBuilder: (context, route) => switch (route) {
+              _TabA() => Builder(
+                builder: (c) {
+                  branchCtx = c;
+                  return const Text(
+                    'a-screen',
+                    textDirection: TextDirection.ltr,
+                  );
+                },
+              ),
+              _TabB() => const Text(
+                'b-screen',
+                textDirection: TextDirection.ltr,
+              ),
+            },
+            chromeBuilder: (context, active, content, sb) => content,
+          ),
+        ),
+      );
+
+      expect(find.text('a-screen'), findsOneWidget);
+
+      // Push within the active branch (branch 0), giving it back-history.
+      await branchCtx.push(const _TabB());
+      await tester.pumpAndSettle();
+      expect(find.text('b-screen'), findsWidgets);
+
+      // The shell's PopScope intercepts the back and pops within the branch.
+      final popScope = tester.widget<PopScope<Object?>>(
+        find.byWidgetPredicate((w) => w is PopScope),
+      );
+      expect(popScope.canPop, isFalse, reason: 'branch has history');
+      final onPop = popScope.onPopInvokedWithResult;
+      expect(onPop, isNotNull);
+      onPop?.call(false, null);
+      await tester.pumpAndSettle();
+      expect(
+        find.text('a-screen'),
+        findsOneWidget,
+        reason: 'back returned to root',
+      );
+    });
+
+    testWidgets('branchScope wraps each branch once', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselShell<_Tab>(
+            branchInitials: const [_TabA(), _TabB()],
+            pageBuilder: (context, route) => const Scaffold(),
+            branchScope: (context, index, child) =>
+                KeyedSubtree(key: Key('scope-$index'), child: child),
+            chromeBuilder: (context, active, content, sb) => content,
+          ),
+        ),
+      );
+
+      // Branch 1 is offstage inside the IndexedStack, so opt into matching it.
+      expect(
+        find.byKey(const Key('scope-0'), skipOffstage: false),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const Key('scope-1'), skipOffstage: false),
+        findsOneWidget,
+      );
+    });
+  });
+}

--- a/packages/kaisel_lint/example/pubspec.lock
+++ b/packages/kaisel_lint/example/pubspec.lock
@@ -168,7 +168,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.2.0"
+    version: "0.3.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/skills/kaisel/ADAPTIVE.md
+++ b/skills/kaisel/ADAPTIVE.md
@@ -107,7 +107,8 @@ update the right pane in place — not stack another detail. Use
 
 ```dart
 onTap: () {
-  context.pushOrReplaceTop(ProductDetail(item.id));
+  context.router<ProductRoute>().pushOrReplaceTop(ProductDetail(item.id));
+  // or, terser: context.pushOrReplaceTop(ProductDetail(item.id));
 }
 ```
 

--- a/skills/kaisel/ADAPTIVE.md
+++ b/skills/kaisel/ADAPTIVE.md
@@ -107,9 +107,7 @@ update the right pane in place — not stack another detail. Use
 
 ```dart
 onTap: () {
-  context.router<ProductRoute>().pushOrReplaceTop(
-    ProductDetail(item.id),
-  );
+  context.pushOrReplaceTop(ProductDetail(item.id));
 }
 ```
 

--- a/skills/kaisel/CODEC.md
+++ b/skills/kaisel/CODEC.md
@@ -72,9 +72,29 @@ class AppCodec extends KaiselConfigCodec<AppRoute> {
 }
 ```
 
-Wire it up by constructing a `KaiselRouteInformationParser` with your
-codec and a `fallback` stack (used when `decode` returns `null`) — no
-subclassing:
+The modern wiring is to hand the codec to `KaiselRouterConfig` via
+`codec:` (plus an optional `fallback:` stack, used when `decode` returns
+`null`). The config builds the parser and a
+`PlatformRouteInformationProvider` for you — passing `codec:` is what
+makes the app URL-addressable:
+
+```dart
+final _config = KaiselRouterConfig<AppRoute>(
+  initial: const Home(),
+  builder: (context, route) => switch (route) { /* ... */ },
+  codec: AppCodec(),
+  fallback: const [Home()],
+);
+
+// build: MaterialApp.router(routerConfig: _config, theme: ...)
+```
+
+Omit `codec:` and the app is URL-less; pass it and the parser +
+provider are wired automatically.
+
+The explicit path stays valid as the lower tier — construct a
+`KaiselRouteInformationParser` with your codec and `fallback` stack (no
+subclassing) and hand it to `MaterialApp.router` yourself:
 
 ```dart
 MaterialApp.router(

--- a/skills/kaisel/GUARDS.md
+++ b/skills/kaisel/GUARDS.md
@@ -193,7 +193,9 @@ List<AppRoute> deepLinkSanitiser(
 ## Per-flow guards
 
 Modal flows can have their own guards independent of the main
-router's guards. Pass `flowGuards` when calling `run`:
+router's guards. Pass `flowGuards` when calling `run`. `flowGuards` are
+typed to the router's route type, so use the typed `context.router<R>()`
+form here (the terse `context.run` covers the no-guards case):
 
 ```dart
 final result = await context.router<AppRoute>().run<String>(

--- a/skills/kaisel/MODAL_FLOWS.md
+++ b/skills/kaisel/MODAL_FLOWS.md
@@ -29,7 +29,7 @@ itself. The flow has:
 |:-----|:--------|
 | `KaiselModalRoute<T>` | Abstract base for routes used as flow entry points. `T` is the typed completion value. |
 | `KaiselRouter.run<T>(flow)` | Opens the flow. Returns `Future<T?>` that completes when the flow completes or dismisses. |
-| `KaiselModalBuilder<R>` | Function passed to `KaiselRouterDelegate(modalBuilder: ...)` — required when the app uses flows. |
+| `KaiselModalBuilder<R>` | Function passed via `modalBuilder:` (on `KaiselRouterConfig` or `KaiselRouterDelegate`) — required when the app uses flows. |
 | `KaiselActiveFlow<R>` | Represents one active flow at runtime (one per `run` call). The delegate iterates these to render flows on top of the main stack. |
 | `context.completeFlow<T>(value)` | From inside a flow screen: complete the flow with `value`. |
 | `context.dismissFlow()` | From inside a flow screen (or in response to a backdrop tap): dismiss with `null`. |
@@ -66,15 +66,19 @@ final class PaymentFlow extends AppRoute
 ### 2. Open the flow with `run<T>`
 
 ```dart
-final cardId = await context.router<AppRoute>().run<CardId>(
-  const AddCardFlow(),
-);
+final cardId = await context.run<CardId>(const AddCardFlow());
 if (cardId != null) {
   // Flow completed with a card id.
 } else {
   // Dismissed.
 }
 ```
+
+`context.run<T>(flow)` is the terse form — it resolves the nearest
+router that accepts the flow route and runs it. The typed form
+`context.router<AppRoute>().run<CardId>(const AddCardFlow())` is
+equivalent and stays valid where you want explicit, compile-time-typed
+router access.
 
 The `Future<T?>` carries the result. `null` is the dismissal signal —
 treat it as a real outcome, not an error.
@@ -109,9 +113,12 @@ enclosing active flow and complete it.
 
 ### 4. Wire up the `modalBuilder`
 
+`modalBuilder:` is a `KaiselRouterConfig` parameter — declare the
+config once at app lifetime and hand it to `MaterialApp.router`:
+
 ```dart
-_delegate = KaiselRouterDelegate<AppRoute>(
-  router: _router,
+final _config = KaiselRouterConfig<AppRoute>(
+  initial: const Home(),
   builder: (context, route) => switch (route) {
     Home() => const HomeScreen(),
     AddCardFlow() => const _AddCardEntryScreen(),
@@ -141,10 +148,14 @@ _delegate = KaiselRouterDelegate<AppRoute>(
     );
   },
 );
+
+// build: MaterialApp.router(routerConfig: _config, theme: ...)
 ```
 
 The `modalBuilder` is required when `run<T>` is used anywhere in the
-app. Without it, `run` throws.
+app. Without it, `run` throws. (The lower-tier explicit form —
+`KaiselRouterDelegate(router:, builder:, modalBuilder:)` — still works
+if you're managing the delegate by hand.)
 
 ## Sub-stack inside a flow
 
@@ -173,9 +184,7 @@ open.
 
 ```dart
 // In a PaymentFlow screen, open a sub-flow to add a card:
-final newCardId = await context.router<AppRoute>().run<CardId>(
-  const AddCardFlow(),
-);
+final newCardId = await context.run<CardId>(const AddCardFlow());
 if (newCardId != null) {
   // The PaymentFlow's state is still here, including its cards list,
   // its selected amount, anything in StatefulWidget state. The

--- a/skills/kaisel/MODAL_FLOWS.md
+++ b/skills/kaisel/MODAL_FLOWS.md
@@ -66,7 +66,8 @@ final class PaymentFlow extends AppRoute
 ### 2. Open the flow with `run<T>`
 
 ```dart
-final cardId = await context.run<CardId>(const AddCardFlow());
+final cardId =
+    await context.router<AppRoute>().run<CardId>(const AddCardFlow());
 if (cardId != null) {
   // Flow completed with a card id.
 } else {
@@ -74,11 +75,11 @@ if (cardId != null) {
 }
 ```
 
-`context.run<T>(flow)` is the terse form — it resolves the nearest
-router that accepts the flow route and runs it. The typed form
-`context.router<AppRoute>().run<CardId>(const AddCardFlow())` is
-equivalent and stays valid where you want explicit, compile-time-typed
-router access.
+The typed `context.router<AppRoute>().run<CardId>(...)` is the idiomatic
+form — it's compile-checked against the family. For brevity,
+`context.run<CardId>(flow)` drops the type parameter and resolves the
+nearest router that accepts the flow at runtime; the deliberate trade is
+that a wrong-family flow throws at runtime instead of failing to compile.
 
 The `Future<T?>` carries the result. `null` is the dismissal signal —
 treat it as a real outcome, not an error.

--- a/skills/kaisel/NAVIGATION.md
+++ b/skills/kaisel/NAVIGATION.md
@@ -1,9 +1,29 @@
 # Navigation methods
 
 Reference for choosing between `push`, `pop`, `set`, `replaceTop`,
-`pushOrReplaceTop`, and `run<T>` on a `KaiselRouter<R>`. Each method
-mutates the stack differently and is appropriate for a different
-situation.
+`pushOrReplaceTop`, and `run<T>`. Each method mutates the stack
+differently and is appropriate for a different situation.
+
+## Two ways to call them
+
+Every verb has two surfaces:
+
+- **Terse `context.*` verbs** — the idiomatic default. `context.push(...)`,
+  `context.pop()`, `context.replaceTop(...)`,
+  `context.pushOrReplaceTop(...)`, `context.set(...)`,
+  `context.run<T>(...)`. These resolve the *nearest* router whose route
+  type **accepts** the argument, walking up the widget tree at runtime.
+  `push`/`pop`/`replaceTop`/`pushOrReplaceTop`/`set` are non-generic;
+  only `run<T>` carries a result type.
+- **Typed `context.router<R>().<verb>`** — the equivalent explicit form.
+  `context.router<R>()` resolves the nearest router of route family `R`,
+  and the verb is then a compile-checked call against that family. Reach
+  for it when typed/explicit router access is the point.
+
+The trade-off: a `context.*` verb given a route from the wrong family
+throws at **runtime**, whereas `context.router<R>().<verb>` makes the
+same mistake a **compile error**. Both lead the verbs in the sections
+below.
 
 ## Quick reference
 
@@ -22,6 +42,8 @@ applying. A guard can reject or transform any proposed stack.
 ## push
 
 ```dart
+context.push(const ProductDetail('sku-42'));
+// Typed equivalent:
 context.router<AppRoute>().push(const ProductDetail('sku-42'));
 ```
 
@@ -42,6 +64,8 @@ sub-screen.
 ## pop
 
 ```dart
+final didPop = await context.pop();
+// Typed equivalent:
 final didPop = await context.router<AppRoute>().pop();
 ```
 
@@ -63,6 +87,8 @@ without a typed result.
 ## replaceTop
 
 ```dart
+context.replaceTop(const ProductDetail('sku-42'));
+// Typed equivalent:
 context.router<AppRoute>().replaceTop(const ProductDetail('sku-42'));
 ```
 
@@ -82,6 +108,8 @@ already below. If you want the user to be able to go back to the
 ## pushOrReplaceTop
 
 ```dart
+context.pushOrReplaceTop(ProductDetail(productId));
+// Typed equivalent:
 context.router<AppRoute>().pushOrReplaceTop(
   ProductDetail(productId),
 );
@@ -112,6 +140,8 @@ items.
 ## set
 
 ```dart
+context.set(const [Home(), ProductList()]);
+// Typed equivalent:
 context.router<AppRoute>().set(const [Home(), ProductList()]);
 ```
 
@@ -137,6 +167,8 @@ changes.
 ## run
 
 ```dart
+final cardId = await context.run<CardId>(const AddCardFlow());
+// Typed equivalent:
 final cardId = await context.router<AppRoute>().run<CardId>(
   const AddCardFlow(),
 );
@@ -169,7 +201,9 @@ sub-flow has a clean entry, multi-step middle, and typed exit.
 
 ## Decision aid
 
-A short decision tree for picking the right method:
+A short decision tree for picking the right method. Reach for the terse
+`context.<verb>` by default; switch to `context.router<R>().<verb>` when
+you want the typed, compile-checked call:
 
 - **Going forward to a new screen?** `push`
 - **Going back?** `pop`
@@ -187,3 +221,4 @@ A short decision tree for picking the right method:
 | Forgetting to handle the `null` result from `run<T>` | `null` means the user dismissed the flow. Treat it as a first-class outcome, not an edge case. |
 | Pop loops to clear deep-link state | Use `set` to atomically replace the stack instead of popping repeatedly. |
 | Pop'ing past the root | `pop` returns `false` when the stack is at one entry. It doesn't throw. Use the return value if you need to know. |
+| Passing a wrong-family route to a terse `context.*` verb | The terse verbs resolve by *accepted argument type* at runtime, so a route from the wrong family throws at runtime. Use `context.router<R>().<verb>` to turn that into a compile error. |

--- a/skills/kaisel/NAVIGATION.md
+++ b/skills/kaisel/NAVIGATION.md
@@ -6,24 +6,27 @@ differently and is appropriate for a different situation.
 
 ## Two ways to call them
 
-Every verb has two surfaces:
+Every verb has two surfaces. Lead with the typed one:
 
-- **Terse `context.*` verbs** — the idiomatic default. `context.push(...)`,
-  `context.pop()`, `context.replaceTop(...)`,
-  `context.pushOrReplaceTop(...)`, `context.set(...)`,
-  `context.run<T>(...)`. These resolve the *nearest* router whose route
-  type **accepts** the argument, walking up the widget tree at runtime.
-  `push`/`pop`/`replaceTop`/`pushOrReplaceTop`/`set` are non-generic;
-  only `run<T>` carries a result type.
-- **Typed `context.router<R>().<verb>`** — the equivalent explicit form.
+- **Typed `context.router<R>().<verb>` — the idiomatic default.**
   `context.router<R>()` resolves the nearest router of route family `R`,
-  and the verb is then a compile-checked call against that family. Reach
-  for it when typed/explicit router access is the point.
+  and the verb is then a compile-checked call against that family: a route
+  from the wrong family is a **compile error**, caught before you run.
+  `context.router<R>()` also hands you the actual `KaiselRouter<R>`, so the
+  full surface (`stack`, `pop`, `replaceTop`, `run`, …) is right there. This
+  is the form to reach for by default — it's the one the type system backs.
+- **Terse `context.<verb>` — a deliberate convenience.** `context.push(...)`,
+  `context.pop()`, `context.replaceTop(...)`, `context.pushOrReplaceTop(...)`,
+  `context.set(...)`, `context.run<T>(...)` drop the `<R>` and resolve the
+  *nearest* router whose route type **accepts** the argument, walking up the
+  tree at runtime. You trade the compile-time family check for brevity: a
+  wrong-family route now throws at **runtime** instead of failing to compile.
+  Reach for it when the terseness clearly earns that trade — e.g. a
+  single-router screen, where there's no wrong family to get wrong.
 
-The trade-off: a `context.*` verb given a route from the wrong family
-throws at **runtime**, whereas `context.router<R>().<verb>` makes the
-same mistake a **compile error**. Both lead the verbs in the sections
-below.
+`push`/`pop`/`replaceTop`/`pushOrReplaceTop`/`set` are non-generic on the
+terse surface; only `run<T>` carries a result type either way. The sections
+below show the typed form first.
 
 ## Quick reference
 
@@ -42,9 +45,9 @@ applying. A guard can reject or transform any proposed stack.
 ## push
 
 ```dart
-context.push(const ProductDetail('sku-42'));
-// Typed equivalent:
 context.router<AppRoute>().push(const ProductDetail('sku-42'));
+// Terse convenience (runtime-resolved):
+context.push(const ProductDetail('sku-42'));
 ```
 
 Adds the route on top of the current stack. The previous top stays
@@ -64,9 +67,9 @@ sub-screen.
 ## pop
 
 ```dart
-final didPop = await context.pop();
-// Typed equivalent:
 final didPop = await context.router<AppRoute>().pop();
+// Terse convenience (runtime-resolved):
+final didPop = await context.pop();
 ```
 
 Removes the top entry. Returns `true` if the pop happened, `false` if
@@ -87,9 +90,9 @@ without a typed result.
 ## replaceTop
 
 ```dart
-context.replaceTop(const ProductDetail('sku-42'));
-// Typed equivalent:
 context.router<AppRoute>().replaceTop(const ProductDetail('sku-42'));
+// Terse convenience (runtime-resolved):
+context.replaceTop(const ProductDetail('sku-42'));
 ```
 
 Removes the current top entry and pushes a new one in its place. The
@@ -108,11 +111,9 @@ already below. If you want the user to be able to go back to the
 ## pushOrReplaceTop
 
 ```dart
+context.router<AppRoute>().pushOrReplaceTop(ProductDetail(productId));
+// Terse convenience (runtime-resolved):
 context.pushOrReplaceTop(ProductDetail(productId));
-// Typed equivalent:
-context.router<AppRoute>().pushOrReplaceTop(
-  ProductDetail(productId),
-);
 ```
 
 If the current top is the same runtime type as the proposed route,
@@ -140,9 +141,9 @@ items.
 ## set
 
 ```dart
-context.set(const [Home(), ProductList()]);
-// Typed equivalent:
 context.router<AppRoute>().set(const [Home(), ProductList()]);
+// Terse convenience (runtime-resolved):
+context.set(const [Home(), ProductList()]);
 ```
 
 Replaces the entire stack with the provided list. Equivalent to
@@ -167,11 +168,11 @@ changes.
 ## run
 
 ```dart
-final cardId = await context.run<CardId>(const AddCardFlow());
-// Typed equivalent:
 final cardId = await context.router<AppRoute>().run<CardId>(
   const AddCardFlow(),
 );
+// Terse convenience (runtime-resolved):
+final cardId = await context.run<CardId>(const AddCardFlow());
 if (cardId != null) {
   // Flow completed with a result.
 } else {
@@ -201,9 +202,9 @@ sub-flow has a clean entry, multi-step middle, and typed exit.
 
 ## Decision aid
 
-A short decision tree for picking the right method. Reach for the terse
-`context.<verb>` by default; switch to `context.router<R>().<verb>` when
-you want the typed, compile-checked call:
+A short decision tree for picking the right method. Reach for the typed
+`context.router<R>().<verb>` by default; drop to the terse `context.<verb>`
+when the brevity clearly earns the runtime family check:
 
 - **Going forward to a new screen?** `push`
 - **Going back?** `pop`

--- a/skills/kaisel/SHELLS.md
+++ b/skills/kaisel/SHELLS.md
@@ -219,6 +219,40 @@ chromeBuilder: (context, activeBranch, branchContent, switchBranch) {
 },
 ```
 
+## Custom branch layout (`branchContentBuilder`)
+
+By default the shell lays the branches out in an `IndexedStack` — that's
+what keeps every branch mounted so the state preservation above works.
+Pass `branchContentBuilder` to swap that for any container (a `PageView`
+for swipeable tabs, a custom animated switcher, …) without giving up the
+shell's back-button routing, scopes, or URL wiring:
+
+```dart
+KaiselBranchedShell.specs(
+  branches: [/* ... */],
+  branchContentBuilder: (context, activeBranch, branches, switchBranch) {
+    return PageView(
+      controller: _pageController,         // your own, synced to activeBranch
+      onPageChanged: switchBranch,         // swipe → switch tab
+      children: branches,
+    );
+  },
+  chromeBuilder: (context, active, branchContent, switchBranch) =>
+      Scaffold(body: branchContent /* ... */),
+)
+```
+
+The builder receives the active index, the per-branch widgets (in branch
+order), and the tab switcher — the same pieces the default `IndexedStack`
+uses.
+
+> **You take over state preservation.** `IndexedStack` keeps every branch
+> alive; a plain `PageView` lazily builds and disposes off-screen pages, so
+> branch stacks reset unless you keep them mounted (e.g. `PageView` with
+> `AutomaticKeepAliveClientMixin` on the branch children, or
+> `KeepAlivePageView`-style wrappers). Keep `switchTo`/`activeBranch` and your
+> container in sync so back-button routing still targets the visible branch.
+
 ## Resolving the right router from context
 
 Inside a branch's screens, `context.router<R>()` resolves to that

--- a/skills/kaisel/SHELLS.md
+++ b/skills/kaisel/SHELLS.md
@@ -21,6 +21,12 @@ section" pattern.
 
 ## Branched shell — the canonical pattern
 
+The recommended setup is the declarative `KaiselBranchedShell.specs(...)`.
+You describe each branch as a `KaiselBranchSpec<R>` and the shell
+**creates, owns, and disposes** one `KaiselRouter` per spec — you never
+construct a `KaiselRouter` or a `BranchedShellRouter`, and each branch's
+stack still survives tab switches.
+
 ```dart
 sealed class HomeRoute extends KaiselRoute { const HomeRoute(); }
 final class HomeView extends HomeRoute { const HomeView(); }
@@ -37,6 +43,56 @@ final class ProductDetail extends ProductRoute {
 sealed class SettingsRoute extends KaiselRoute { const SettingsRoute(); }
 final class SettingsHome extends SettingsRoute { const SettingsHome(); }
 
+KaiselBranchedShell.specs(
+  branches: [
+    KaiselBranchSpec<HomeRoute>(
+      initial: const HomeView(),
+      builder: (context, route) => switch (route) {
+        HomeView() => const HomeScreen(),
+      },
+    ),
+    KaiselBranchSpec<ProductRoute>(
+      initial: const ProductList(),
+      builder: (context, route) => switch (route) {
+        ProductList() => const ProductListScreen(),
+        ProductDetail(:final id) => ProductDetailScreen(id: id),
+      },
+    ),
+    KaiselBranchSpec<SettingsRoute>(
+      initial: const SettingsHome(),
+      builder: (context, route) => switch (route) {
+        SettingsHome() => const SettingsScreen(),
+      },
+    ),
+  ],
+  chromeBuilder: (context, activeBranch, branchContent, switchBranch) {
+    return Scaffold(
+      body: branchContent,
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: activeBranch,
+        onTap: switchBranch,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+          BottomNavigationBarItem(icon: Icon(Icons.shop), label: 'Shop'),
+          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
+        ],
+      ),
+    );
+  },
+  // optional: initialBranch:
+);
+```
+
+Each spec accepts optional `guards:`, `pageWrapper:`, and `scope:`. For
+an adaptive (absorbing) page builder, use the
+`KaiselBranchSpec<R>.adaptive(initial:, builder:)` constructor.
+
+**Lower tier — the explicit form.** When you need to hold the branch
+routers yourself, construct each `KaiselRouter`, wire them into a
+`BranchedShellRouter`, and pass `KaiselBranch<R>(router:, pageBuilder:)`
+entries. You own disposal in this form.
+
+```dart
 class _AppShellState extends State<AppShell> {
   late final _homeRouter =
       KaiselRouter<HomeRoute>(initial: const HomeView());
@@ -180,19 +236,22 @@ If you need to mutate the top-level state (logout, switch shell route),
 use `context.router<AppRoute>()`. If you need to navigate within the
 current branch, use the branch's type.
 
-`KaiselBranchedShellContextX` is an extension that adds shell-specific
-helpers (e.g., reading the current active branch index from any
-descendant of the shell).
+`context.shell()` returns a `KaiselShellController` from any descendant
+of the shell — one accessor for either shell flavour. It exposes
+`switchTo(i)`, `activeBranch`, `branchCount`, and `current` (the active
+branch's `KaiselNavigator`, which carries its stack, `canPop`, and
+`pop`).
 
 **`context.router<R>()` does NOT work inside the `chromeBuilder`.** Each
-branch's `RouterScope<R>` is installed *inside* its `KaiselBranch`, which is
+branch's `RouterScope<R>` is installed *inside* its branch, which is
 a **descendant** of the chrome — and context lookups only walk upward. There
 is also no single "branch router" at the chrome level: the chrome wraps every
 branch, each with a different `R`. From the chrome:
 
 - use the `activeBranch` / `switchBranch` arguments you're handed, or
-  `context.branchedShell()` for the full aggregator (`switchTo`, `activeBranch`,
-  `current`, `currentCanPop`, `popCurrent`);
+  `context.shell()` for the controller (`switchTo`, `activeBranch`,
+  `branchCount`, `current`). Read the active branch's stack, `canPop`,
+  and `pop` through `context.shell().current`;
 - `context.router<AppRoute>()` (your root route type) resolves to the **main**
   router — it sits above the shell — so use it to push onto the root stack from
   the chrome.
@@ -241,8 +300,9 @@ KaiselShell<TabRoute>(
 ```
 
 Inside a branch screen, `context.router<TabRoute>()` resolves to the
-active branch's router and `context.shellRouter<TabRoute>()` to the
-shell aggregator. The trade-off vs. `KaiselBranchedShell`: every branch
+active branch's router and `context.shell()` to the shell controller
+(`switchTo`, `activeBranch`, `branchCount`, `current`). The trade-off
+vs. `KaiselBranchedShell`: every branch
 shares `TabRoute`, so the compiler can't stop you pushing a "profile"
 route into the "home" tab. When tabs need **different** route types (and
 that compile-time guard), use `KaiselBranchedShell` with per-branch

--- a/skills/kaisel/SKILL.md
+++ b/skills/kaisel/SKILL.md
@@ -204,35 +204,39 @@ class _AppState extends State<App> {
 
 ## 3. Navigating
 
-The idiomatic terse default is the `context.*` verbs — no type parameter:
+The idiomatic default is the typed `context.router<R>()` — the verb is then
+compile-checked against the family, so a wrong-family route is a compile
+error, and you also get the full `KaiselRouter<R>` surface (`stack`, `pop`,
+`run`, …):
 
 ```dart
 // From any widget inside the delegate's tree:
-context.push(const ProductDetail('sku-42'));
-context.pop();
-context.replaceTop(const ProductList());
-context.pushOrReplaceTop(const ProductDetail('sku-99'));
-context.set(const [Home(), ProductList()]);
-final result = await context.run<bool>(const ConfirmFlow());
+context.router<AppRoute>().push(const ProductDetail('sku-42'));
+context.router<AppRoute>().pop();
+context.router<AppRoute>().replaceTop(const ProductList());
+context.router<AppRoute>().set(const [Home(), ProductList()]);
+final result = await context.router<AppRoute>().run<bool>(const ConfirmFlow());
 ```
 
-These resolve the nearest router whose route type *accepts* the argument
-by walking up the widget tree at runtime. The trade-off: a wrong-family
-route throws at runtime rather than failing to compile.
-`push`/`pop`/`replaceTop`/`pushOrReplaceTop`/`set` are non-generic; only
-`run<T>` carries a result type.
+`context.router<R>()` resolves to the nearest enclosing router — the modal
+flow's router if inside a flow, the branch's router if inside a shell branch,
+otherwise the main router. The type parameter disambiguates which family.
 
-When you want typed/explicit router access — or a compile-time guarantee
-that the route belongs to the family — reach for `context.router<R>()`:
+For brevity, the terse `context.*` verbs drop the type parameter:
 
 ```dart
-context.router<AppRoute>().push(const ProductDetail('sku-42'));
+context.push(const ProductDetail('sku-42'));
+context.pop();
+context.pushOrReplaceTop(const ProductDetail('sku-99'));
+final quantity = await context.run<int>(const AddCardFlow());
 ```
 
-`context.router<R>()` resolves to the nearest enclosing router — the
-modal flow's router if inside a flow, the branch's router if inside a
-shell branch, otherwise the main router. The type parameter disambiguates
-which router you mean.
+These resolve the nearest router whose route type *accepts* the argument by
+walking up the tree at runtime. The deliberate trade: a wrong-family route
+throws at **runtime** rather than failing to compile — so reach for them when
+the terseness clearly earns that trade (a single-router screen, say).
+`push`/`pop`/`replaceTop`/`pushOrReplaceTop`/`set` are non-generic; only
+`run<T>` carries a result type.
 
 > For decisions between `push`, `replaceTop`, `pushOrReplaceTop`, `set`,
 > and `run<T>`, read [NAVIGATION.md](./NAVIGATION.md).

--- a/skills/kaisel/SKILL.md
+++ b/skills/kaisel/SKILL.md
@@ -71,6 +71,7 @@ Read these only when the topic at hand demands the depth.
 | Type | Purpose |
 |:-----|:--------|
 | `KaiselRoute` | Base class for every route. Subclasses are sealed data carriers. |
+| `KaiselRouterConfig<R>` | A `RouterConfig` bundling router + delegate (+ URL parser/provider when given a `codec`) for `MaterialApp.router(routerConfig:)`. Hold as a top-level `final`; `.router` exposes the bundled `KaiselRouter<R>`. |
 | `KaiselRouter<R>` | Holds the stack of routes for type `R`. Mutated via `push`, `pop`, `set`, `replaceTop`, `pushOrReplaceTop`, `run<T>`. |
 | `KaiselRouterDelegate<R>` | `RouterDelegate` that drives Flutter's `Router` from a `KaiselRouter`. Takes a `builder`, optional `pageWrapper`, optional `modalBuilder`. |
 | `KaiselPageBuilder<R>` | `Widget Function(BuildContext, R)`. Pattern-match on the route to produce the screen. |
@@ -121,13 +122,51 @@ final class ProductDetail extends AppRoute {
 
 ## 2. Wiring up the router
 
+Hold a `KaiselRouterConfig<R>` as a top-level `final` and hand it
+straight to `MaterialApp.router(routerConfig:)`. It bundles the router,
+the delegate, and — when you give it a `codec:` — the URL parser and a
+`PlatformRouteInformationProvider`. No `StatefulWidget`, no manual
+delegate, no hand-rolled parser, no `dispose`.
+
 ```dart
-class App extends StatefulWidget {
+final _config = KaiselRouterConfig<AppRoute>(
+  initial: const Home(),
+  builder: (context, route) => switch (route) {
+    Home() => const HomeScreen(),
+    ProductList(:final category) => ProductListScreen(category: category),
+    ProductDetail(:final id) => ProductDetailScreen(id: id),
+  },
+  // optional: guards:, pageWrapper:, modalBuilder:, codec:, fallback:
+);
+
+class App extends StatelessWidget {
   const App({super.key});
   @override
-  State<App> createState() => _AppState();
+  Widget build(BuildContext context) {
+    return MaterialApp.router(routerConfig: _config);
+  }
 }
+```
 
+Omit `codec:` and you get a URL-less, delegate-only app. Pass `codec:`
+(plus an optional `fallback:`) and the config wires the
+`KaiselRouteInformationParser` and a `PlatformRouteInformationProvider`
+for you — the app is URL-addressable. The bundled router is reachable as
+`_config.router` (a `KaiselRouter<AppRoute>`) for imperative navigation
+outside the widget tree. Call `_config.dispose()` only when a `State`
+owns its lifecycle; a top-level `final` lives for the whole app.
+
+The `switch` is exhaustive. Add a new sealed variant and the compiler
+points at every page builder, codec, and transition wrapper that needs
+to handle it. That's the type safety the library is designed to give
+you in load-bearing form, not just on paper.
+
+**Lower tier — the explicit form.** Constructing a `KaiselRouter`, a
+`KaiselRouterDelegate`, and a `KaiselRouteInformationParser` by hand
+still works, and is the right tool when a `State` must own each piece's
+lifecycle:
+
+```dart
 class _AppState extends State<App> {
   late final KaiselRouter<AppRoute> _router;
   late final KaiselRouterDelegate<AppRoute> _delegate;
@@ -163,19 +202,31 @@ class _AppState extends State<App> {
 }
 ```
 
-The `switch` is exhaustive. Add a new sealed variant and the compiler
-points at every page builder, codec, and transition wrapper that needs
-to handle it. That's the type safety the library is designed to give
-you in load-bearing form, not just on paper.
-
 ## 3. Navigating
+
+The idiomatic terse default is the `context.*` verbs — no type parameter:
 
 ```dart
 // From any widget inside the delegate's tree:
+context.push(const ProductDetail('sku-42'));
+context.pop();
+context.replaceTop(const ProductList());
+context.pushOrReplaceTop(const ProductDetail('sku-99'));
+context.set(const [Home(), ProductList()]);
+final result = await context.run<bool>(const ConfirmFlow());
+```
+
+These resolve the nearest router whose route type *accepts* the argument
+by walking up the widget tree at runtime. The trade-off: a wrong-family
+route throws at runtime rather than failing to compile.
+`push`/`pop`/`replaceTop`/`pushOrReplaceTop`/`set` are non-generic; only
+`run<T>` carries a result type.
+
+When you want typed/explicit router access — or a compile-time guarantee
+that the route belongs to the family — reach for `context.router<R>()`:
+
+```dart
 context.router<AppRoute>().push(const ProductDetail('sku-42'));
-context.router<AppRoute>().pop();
-context.router<AppRoute>().replaceTop(const ProductList());
-context.router<AppRoute>().set(const [Home(), ProductList()]);
 ```
 
 `context.router<R>()` resolves to the nearest enclosing router — the

--- a/skills/kaisel/TRANSITIONS.md
+++ b/skills/kaisel/TRANSITIONS.md
@@ -108,15 +108,24 @@ Page<Object?> _appPageWrapper(KaiselPageWrapperContext<AppRoute> ctx) {
 }
 ```
 
-### 3. Pass it to the delegate
+### 3. Pass it to the config
+
+`pageWrapper:` is a `KaiselRouterConfig` parameter — declare the config
+once at app lifetime and hand it to `MaterialApp.router`:
 
 ```dart
-_delegate = KaiselRouterDelegate<AppRoute>(
-  router: _router,
+final _config = KaiselRouterConfig<AppRoute>(
+  initial: const Home(),
   builder: /* ... */,
   pageWrapper: _appPageWrapper,
 );
+
+// build: MaterialApp.router(routerConfig: _config, theme: ...)
 ```
+
+(The lower-tier explicit form still works — pass `pageWrapper:` to
+`KaiselRouterDelegate(router:, builder:, pageWrapper:)` if you're
+managing the delegate by hand.)
 
 ## Pattern shapes you'll write
 


### PR DESCRIPTION
Reduce the two ergonomics complaints — verbose setup and verbose call sites — with an additive convenience layer over the explicit, typed core. Nothing in the existing API changes; all 127 prior kaisel tests still pass.

- KaiselRouterConfig: a `RouterConfig<KaiselConfig<R>>` that bundles router + delegate (+ parser/provider when a codec is given) into the single object `MaterialApp.router(routerConfig:)` expects. Hold it as a top-level final — no StatefulWidget, no hand-rolled parser, no dispose. URL-less and codec paths both covered.

- context.push/pop/replaceTop/pushOrReplaceTop/set/run<T>: navigation that resolves the nearest `RouterScope` whose route type the argument belongs to (reified-generics accepts-walk via visitAncestorElements, no dependency). Trade vs `context.router<R>()`: a wrong-family route throws at runtime instead of failing to compile; the typed form stays as the escape hatch.

- KaiselShellController + context.shell(): one accessor for switching tabs in either shell flavour, replacing the split `context.branchedShell()` / `context.shellRouter<R>()` (kept for back-compat).

- Tests (ergonomics_test.dart): nearest-router push/pop, cross-family routing, no-accepting-router error, context.shell() tab switch, config drives `MaterialApp.router`, codec deep-link decode, and `context.run` flow routing.

- Example: `main_terse.dart` (before/after) and `main_media_cataloguer` converted off its StatefulWidget/_NoopParser setup.