### PR TITLE
test(kaisel): behavioural tests for previously-untested paths

### DIFF
--- a/packages/kaisel/test/ergonomics_test.dart
+++ b/packages/kaisel/test/ergonomics_test.dart
@@ -729,4 +729,135 @@ void main() {
       expect(a.stack.length, 1, reason: 'back popped within the branch');
     });
   });
+
+  group('modal flow rendering', () {
+    KaiselRouterConfig<_R> flowConfig() => KaiselRouterConfig<_R>(
+      initial: const _A(),
+      builder: (context, route) => switch (route) {
+        _A() => const Text('home', textDirection: TextDirection.ltr),
+        _B() => const Text('B', textDirection: TextDirection.ltr),
+        _Flow() => const Text('flow', textDirection: TextDirection.ltr),
+      },
+      modalBuilder: (context, flowRoute, flowChild) =>
+          Material(child: flowChild),
+    );
+
+    PopScope<Object?> flowPopScope(WidgetTester tester) => tester
+        .widgetList<PopScope<Object?>>(
+          find.byWidgetPredicate((w) => w is PopScope),
+        )
+        .firstWhere((p) => !p.canPop);
+
+    testWidgets(
+      'back inside a flow pops its sub-stack, then dismisses at root',
+      (tester) async {
+        final config = flowConfig();
+        addTearDown(config.dispose);
+        await tester.pumpWidget(MaterialApp.router(routerConfig: config));
+
+        final result = config.router.run<bool>(const _Flow());
+        await tester.pumpAndSettle();
+        expect(find.text('flow'), findsOneWidget);
+
+        // Give the flow's own sub-stack some history.
+        final flow = config.router.activeFlows.last;
+        await flow.router.push(const _B());
+        await tester.pumpAndSettle();
+        expect(flow.router.stack.length, 2);
+
+        void back() {
+          final cb = flowPopScope(tester).onPopInvokedWithResult;
+          expect(cb, isNotNull);
+          cb?.call(false, null);
+        }
+
+        // First back: pops within the flow's sub-stack.
+        back();
+        await tester.pumpAndSettle();
+        expect(
+          flow.router.stack.length,
+          1,
+          reason: 'popped the flow sub-stack',
+        );
+
+        // Second back: flow is at root → dismiss with null.
+        back();
+        await tester.pumpAndSettle();
+        expect(await result, isNull, reason: 'flow dismissed');
+      },
+    );
+
+    testWidgets(
+      'an adaptive main delegate renders a flow as a standalone page',
+      (tester) async {
+        // Exercises the adaptive→simple page-builder adapter for flow screens.
+        final config = KaiselRouterConfig<_R>.adaptive(
+          initial: const _A(),
+          builder: (context, route, stack) => KaiselStandalonePage(
+            Text(switch (route) {
+              _A() => 'A',
+              _B() => 'B',
+              _Flow() => 'flow-screen',
+            }, textDirection: TextDirection.ltr),
+          ),
+          modalBuilder: (context, flowRoute, flowChild) =>
+              Material(child: flowChild),
+        );
+        addTearDown(config.dispose);
+        await tester.pumpWidget(MaterialApp.router(routerConfig: config));
+
+        final result = config.router.run<bool>(const _Flow());
+        await tester.pumpAndSettle();
+        expect(find.text('flow-screen'), findsOneWidget);
+
+        config.router.completeFlow<bool>(true);
+        expect(await result, isTrue);
+      },
+    );
+  });
+
+  group('KaiselBranch.adaptive pageWrapper', () {
+    testWidgets('an adaptive branch applies its pageWrapper', (tester) async {
+      final a = KaiselRouter<_BranchR>(initial: const _X());
+      final b = KaiselRouter<_R>(initial: const _A());
+      final shell = BranchedShellRouter(branches: [a, b]);
+      addTearDown(shell.dispose);
+      addTearDown(a.dispose);
+      addTearDown(b.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselBranchedShell(
+            shell: shell,
+            branches: [
+              KaiselBranch<_BranchR>.adaptive(
+                router: a,
+                pageBuilder: (context, route, stack) =>
+                    const KaiselStandalonePage(
+                      Text('x', textDirection: TextDirection.ltr),
+                    ),
+                pageWrapper: (ctx) => MaterialPage<Object?>(
+                  key: ctx.key,
+                  child: KeyedSubtree(
+                    key: const Key('adaptive-wrapped'),
+                    child: ctx.child,
+                  ),
+                ),
+              ),
+              KaiselBranch<_R>(
+                router: b,
+                pageBuilder: (c, r) => const Scaffold(),
+              ),
+            ],
+            chromeBuilder: (c, active, content, sb) => content,
+          ),
+        ),
+      );
+
+      expect(
+        find.byKey(const Key('adaptive-wrapped'), skipOffstage: false),
+        findsOneWidget,
+      );
+    });
+  });
 }

--- a/packages/kaisel/test/ergonomics_test.dart
+++ b/packages/kaisel/test/ergonomics_test.dart
@@ -155,7 +155,6 @@ void main() {
       addTearDown(main.dispose);
       addTearDown(branch.dispose);
 
-      // main scope above, branch scope nearer the leaf.
       late BuildContext ctx;
       await tester.pumpWidget(
         MaterialApp(
@@ -259,7 +258,6 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: KaiselBranchedShell.specs(
-            // Declarative — no KaiselRouter constructed here.
             branches: [
               KaiselBranchSpec<_BranchR>(
                 initial: const _X(),
@@ -293,16 +291,14 @@ void main() {
         ),
       );
 
-      // The shell created the branch routers from the specs.
       expect(find.text('b0-X'), findsOneWidget);
 
-      // Push into branch 0 via context.push (resolves to the _BranchR router).
       await branch0.push(const _Y());
       await tester.pumpAndSettle();
       expect(find.text('b0-Y'), findsOneWidget);
 
-      // Switch away and back — the branch's stack must survive (the routers
-      // are created once, not rebuilt per switch).
+      // The branch's stack must survive a switch away and back: the routers
+      // are created once, not rebuilt per switch.
       switchTo(1);
       await tester.pumpAndSettle();
       expect(find.text('b1-A'), findsOneWidget);
@@ -341,7 +337,6 @@ void main() {
             branchContentBuilder: (context, active, branches, switchBranch) {
               receivedActive = active;
               receivedCount = branches.length;
-              // A PageView instead of the default IndexedStack.
               return PageView(children: branches);
             },
             chromeBuilder: (context, active, content, sb) => content,
@@ -349,8 +344,6 @@ void main() {
         ),
       );
 
-      // The custom builder ran with the shell's active index and branch list,
-      // and a PageView is in the tree — no IndexedStack.
       expect(receivedActive, 0);
       expect(receivedCount, 2);
       expect(find.byType(PageView), findsOneWidget);
@@ -383,8 +376,6 @@ void main() {
     testWidgets('wires the codec so a deep link decodes to the stack', (
       tester,
     ) async {
-      // The platform launches the app at /b; the config's parser + provider
-      // should decode it into [_B()].
       tester.platformDispatcher.defaultRouteNameTestValue = '/b';
       addTearDown(tester.platformDispatcher.clearDefaultRouteNameTestValue);
 
@@ -438,13 +429,11 @@ void main() {
       addTearDown(config.dispose);
 
       await tester.pumpWidget(MaterialApp.router(routerConfig: config));
-      expect(find.text('A'), findsOneWidget); // master alone
+      expect(find.text('A'), findsOneWidget);
 
       await config.router.push(const _B());
       await tester.pumpAndSettle();
 
-      // Absorbed into one page: both master and detail render, and the
-      // standalone master page is gone.
       expect(find.text('master-A'), findsOneWidget);
       expect(find.text('detail-B'), findsOneWidget);
       expect(find.text('A'), findsNothing);
@@ -759,7 +748,6 @@ void main() {
         await tester.pumpAndSettle();
         expect(find.text('flow'), findsOneWidget);
 
-        // Give the flow's own sub-stack some history.
         final flow = config.router.activeFlows.last;
         await flow.router.push(const _B());
         await tester.pumpAndSettle();
@@ -771,7 +759,6 @@ void main() {
           cb?.call(false, null);
         }
 
-        // First back: pops within the flow's sub-stack.
         back();
         await tester.pumpAndSettle();
         expect(
@@ -780,7 +767,6 @@ void main() {
           reason: 'popped the flow sub-stack',
         );
 
-        // Second back: flow is at root → dismiss with null.
         back();
         await tester.pumpAndSettle();
         expect(await result, isNull, reason: 'flow dismissed');
@@ -790,7 +776,6 @@ void main() {
     testWidgets(
       'an adaptive main delegate renders a flow as a standalone page',
       (tester) async {
-        // Exercises the adaptive→simple page-builder adapter for flow screens.
         final config = KaiselRouterConfig<_R>.adaptive(
           initial: const _A(),
           builder: (context, route, stack) => KaiselStandalonePage(

--- a/packages/kaisel/test/kaisel_listenable_builder_test.dart
+++ b/packages/kaisel/test/kaisel_listenable_builder_test.dart
@@ -66,7 +66,6 @@ void main() {
     );
     expect(builds, 1);
 
-    // Tear the builder out of the tree, then mutate the router.
     await tester.pumpWidget(const SizedBox());
     await router.push(const _B());
     await tester.pump();
@@ -122,12 +121,10 @@ void main() {
         ),
       );
 
-      // Bound to A: a 2-deep A renders "depth 2".
       await routerA.push(const _B());
       await tester.pumpWidget(buildWith(routerA));
       expect(find.text('depth 2'), findsOneWidget);
 
-      // Rebuild the same position bound to B (still 1-deep).
       await tester.pumpWidget(buildWith(routerB));
       expect(
         find.text('depth 1'),
@@ -135,7 +132,6 @@ void main() {
         reason: 'output must reflect the new router B',
       );
 
-      // A change to the NEW router B now rebuilds the widget.
       final buildsBeforeB = builds;
       await routerB.push(const _B());
       await tester.pump();
@@ -179,7 +175,6 @@ void main() {
     expect(fromA1, equals(fromA2));
     expect(fromA1.hashCode, equals(fromA2.hashCode));
 
-    // Different router: not equal.
     expect(fromA1, isNot(equals(fromB)));
   });
 }

--- a/packages/kaisel/test/kaisel_listenable_builder_test.dart
+++ b/packages/kaisel/test/kaisel_listenable_builder_test.dart
@@ -96,4 +96,90 @@ void main() {
       expect(notifications, 1, reason: 'a removed listener must not fire');
     },
   );
+
+  testWidgets(
+    'KaiselListenableBuilder rewires to the new router when the router prop '
+    'changes',
+    (tester) async {
+      final routerA = KaiselRouter<_R>(initial: const _A());
+      final routerB = KaiselRouter<_R>(initial: const _A());
+      addTearDown(routerA.dispose);
+      addTearDown(routerB.dispose);
+
+      var builds = 0;
+
+      Widget buildWith(KaiselRouter<_R> router) => Directionality(
+        textDirection: TextDirection.ltr,
+        child: KaiselListenableBuilder<_R>(
+          // Same widget position across both pumps so the State is reused
+          // and didUpdateWidget runs instead of a fresh initState.
+          key: const ValueKey('builder'),
+          router: router,
+          builder: (context, _) {
+            builds++;
+            return Text('depth ${router.depth}');
+          },
+        ),
+      );
+
+      // Bound to A: a 2-deep A renders "depth 2".
+      await routerA.push(const _B());
+      await tester.pumpWidget(buildWith(routerA));
+      expect(find.text('depth 2'), findsOneWidget);
+
+      // Rebuild the same position bound to B (still 1-deep).
+      await tester.pumpWidget(buildWith(routerB));
+      expect(
+        find.text('depth 1'),
+        findsOneWidget,
+        reason: 'output must reflect the new router B',
+      );
+
+      // A change to the NEW router B now rebuilds the widget.
+      final buildsBeforeB = builds;
+      await routerB.push(const _B());
+      await tester.pump();
+      expect(
+        builds,
+        greaterThan(buildsBeforeB),
+        reason: 'a change to the new router must trigger a rebuild',
+      );
+      expect(find.text('depth 2'), findsOneWidget);
+
+      // A change to the OLD router A must NOT rebuild the widget: the old
+      // listener was removed in didUpdateWidget.
+      final buildsBeforeA = builds;
+      await routerA.push(const _A());
+      await tester.pump();
+      expect(
+        builds,
+        buildsBeforeA,
+        reason: 'a change to the old router must not trigger a rebuild',
+      );
+      expect(
+        find.text('depth 2'),
+        findsOneWidget,
+        reason: 'output must still reflect router B, not A',
+      );
+    },
+  );
+
+  test('asListenable equality reflects the underlying router', () async {
+    final routerA = KaiselRouter<_R>(initial: const _A());
+    final routerB = KaiselRouter<_R>(initial: const _A());
+    addTearDown(routerA.dispose);
+    addTearDown(routerB.dispose);
+
+    final fromA1 = routerA.asListenable();
+    final fromA2 = routerA.asListenable();
+    final fromB = routerB.asListenable();
+
+    // Same router: equal and equal hashCode, so ListenableBuilder treats
+    // repeated asListenable() calls as the same listenable and avoids churn.
+    expect(fromA1, equals(fromA2));
+    expect(fromA1.hashCode, equals(fromA2.hashCode));
+
+    // Different router: not equal.
+    expect(fromA1, isNot(equals(fromB)));
+  });
 }

--- a/packages/kaisel/test/kaisel_module_test.dart
+++ b/packages/kaisel/test/kaisel_module_test.dart
@@ -6,8 +6,6 @@ import 'package:kaisel/src/kaisel_router_delegate.dart'
 import 'package:kaisel_core/framework.dart'
     show KaiselNestedHandle, KaiselNestedHost;
 
-// Fixture: a small module under test.
-
 sealed class _CheckoutRoute extends KaiselRoute {
   const _CheckoutRoute();
 }
@@ -145,10 +143,8 @@ void main() {
 
     test('buildPage pattern-matches over the sealed type', () {
       const module = _TestCheckoutModule();
-      // We can't easily check returned widget identity without a
-      // BuildContext, but we can check the resolver doesn't throw.
-      // Use a fake context via a Builder to get a real one would be
-      // overkill; just hit the switch with each case.
+      // A real BuildContext isn't needed: the resolver doesn't dereference
+      // it, so a fake context lets us hit each switch case directly.
       final widgets = <Widget>[
         module.buildPage(_FakeContext(), const _Cart()),
         module.buildPage(_FakeContext(), const _Shipping()),
@@ -170,7 +166,6 @@ void main() {
           ),
         );
 
-        // The Cart screen is the initial page.
         expect(find.byKey(const ValueKey('cart')), findsOneWidget);
         expect(find.byKey(const ValueKey('ship')), findsNothing);
       },
@@ -187,7 +182,6 @@ void main() {
           ),
         );
 
-        // The shipping screen (top of initialStack) is shown.
         expect(find.byKey(const ValueKey('ship')), findsOneWidget);
       },
     );
@@ -220,8 +214,6 @@ void main() {
           ),
         ),
       );
-      // Replace with a different widget — the mount should dispose
-      // cleanly. Any disposal error would be caught by tester.
       await tester.pumpWidget(const MaterialApp(home: SizedBox()));
       expect(find.byKey(const ValueKey('cart')), findsNothing);
     });
@@ -238,8 +230,6 @@ void main() {
           ),
         );
 
-        // Push a second route into the module's own router. The mount
-        // listens on the router and must rebuild to render the new top.
         await router.push(const _Shipping());
         await tester.pumpAndSettle();
 
@@ -259,12 +249,10 @@ void main() {
         ),
       );
 
-      // Give the module in-branch history: [Cart, Shipping].
       await router.push(const _Shipping());
       await tester.pumpAndSettle();
       expect(router.stack, const [_Cart(), _Shipping()]);
 
-      // Fire the module's PopScope back handler with didPop == false.
       final popScope = tester.widget<PopScope<Object?>>(
         find.byWidgetPredicate((w) => w is PopScope<Object?>),
       );
@@ -273,7 +261,6 @@ void main() {
       cb?.call(false, null);
       await tester.pumpAndSettle();
 
-      // The module popped its own stack first — Shipping is gone.
       expect(router.stack, const [_Cart()]);
       expect(find.byKey(const ValueKey('cart')), findsOneWidget);
       expect(find.byKey(const ValueKey('ship')), findsNothing);
@@ -304,16 +291,13 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        // The router in effect is the new one, not the old one.
         expect(identical(firstRouter, secondRouter), isFalse);
 
-        // Pushing into the NEW router is what the mount now reflects.
         await secondRouter.push(const _Confirm());
         await tester.pumpAndSettle();
         expect(find.byKey(const ValueKey('confirm')), findsOneWidget);
 
-        // The old router was torn down by the rewire — it's disposed, so
-        // it can no longer drive any UI.
+        // The rewire disposed the old router, so it can no longer be used.
         expect(
           () => firstRouter.push(const _Shipping()),
           throwsA(isA<StateError>()),
@@ -338,12 +322,10 @@ void main() {
           ),
         );
 
-        // The mount registered its real (private) handle with our host.
         final handle = host.registered;
         expect(handle, isNotNull);
         expect(router.stack, const [_Cart()]);
 
-        // Replaying a KaiselModuleConfig replays its stack into the router.
         await handle?.restoreFromConfig(
           KaiselModuleConfig(stack: const [_Cart(), _Shipping(), _Confirm()]),
         );
@@ -351,7 +333,6 @@ void main() {
         expect(router.stack, const [_Cart(), _Shipping(), _Confirm()]);
         expect(find.byKey(const ValueKey('confirm')), findsOneWidget);
 
-        // A non-module config is silently ignored — the stack is untouched.
         await handle?.restoreFromConfig(
           KaiselShellConfig(
             activeBranch: 0,

--- a/packages/kaisel/test/kaisel_module_test.dart
+++ b/packages/kaisel/test/kaisel_module_test.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kaisel/kaisel.dart';
+import 'package:kaisel/src/kaisel_router_delegate.dart'
+    show KaiselNestedHostScope;
+import 'package:kaisel_core/framework.dart'
+    show KaiselNestedHandle, KaiselNestedHost;
 
 // Fixture: a small module under test.
 
@@ -221,7 +225,158 @@ void main() {
       await tester.pumpWidget(const MaterialApp(home: SizedBox()));
       expect(find.byKey(const ValueKey('cart')), findsNothing);
     });
+
+    testWidgets(
+      'the mount rebuilds and renders the new top when its router pushes',
+      (tester) async {
+        late KaiselRouter<_CheckoutRoute> router;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: KaiselModuleMount<_CheckoutRoute>(
+              module: _CaptureRouterModule(onBuild: (r) => router = r),
+            ),
+          ),
+        );
+
+        // Push a second route into the module's own router. The mount
+        // listens on the router and must rebuild to render the new top.
+        await router.push(const _Shipping());
+        await tester.pumpAndSettle();
+
+        expect(find.byKey(const ValueKey('ship')), findsOneWidget);
+      },
+    );
+
+    testWidgets('back inside a module pops the module stack before the host', (
+      tester,
+    ) async {
+      late KaiselRouter<_CheckoutRoute> router;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselModuleMount<_CheckoutRoute>(
+            module: _CaptureRouterModule(onBuild: (r) => router = r),
+          ),
+        ),
+      );
+
+      // Give the module in-branch history: [Cart, Shipping].
+      await router.push(const _Shipping());
+      await tester.pumpAndSettle();
+      expect(router.stack, const [_Cart(), _Shipping()]);
+
+      // Fire the module's PopScope back handler with didPop == false.
+      final popScope = tester.widget<PopScope<Object?>>(
+        find.byWidgetPredicate((w) => w is PopScope<Object?>),
+      );
+      final cb = popScope.onPopInvokedWithResult;
+      expect(cb, isNotNull);
+      cb?.call(false, null);
+      await tester.pumpAndSettle();
+
+      // The module popped its own stack first — Shipping is gone.
+      expect(router.stack, const [_Cart()]);
+      expect(find.byKey(const ValueKey('cart')), findsOneWidget);
+      expect(find.byKey(const ValueKey('ship')), findsNothing);
+    });
+
+    testWidgets(
+      'swapping in a different module instance rewires to the new router',
+      (tester) async {
+        late KaiselRouter<_CheckoutRoute> firstRouter;
+        late KaiselRouter<_CheckoutRoute> secondRouter;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: KaiselModuleMount<_CheckoutRoute>(
+              module: _CaptureRouterModule(onBuild: (r) => firstRouter = r),
+            ),
+          ),
+        );
+
+        // A distinct (non-identical) module instance fires didUpdateWidget,
+        // which disposes the old router and builds a fresh one.
+        await tester.pumpWidget(
+          MaterialApp(
+            home: KaiselModuleMount<_CheckoutRoute>(
+              module: _CaptureRouterModule(onBuild: (r) => secondRouter = r),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // The router in effect is the new one, not the old one.
+        expect(identical(firstRouter, secondRouter), isFalse);
+
+        // Pushing into the NEW router is what the mount now reflects.
+        await secondRouter.push(const _Confirm());
+        await tester.pumpAndSettle();
+        expect(find.byKey(const ValueKey('confirm')), findsOneWidget);
+
+        // The old router was torn down by the rewire — it's disposed, so
+        // it can no longer drive any UI.
+        expect(
+          () => firstRouter.push(const _Shipping()),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
+
+    testWidgets(
+      'restoreFromConfig replays a captured stack; a foreign config is a no-op',
+      (tester) async {
+        late KaiselRouter<_CheckoutRoute> router;
+        final host = _CapturingHost();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: KaiselNestedHostScope(
+              host: host,
+              child: KaiselModuleMount<_CheckoutRoute>(
+                module: _CaptureRouterModule(onBuild: (r) => router = r),
+              ),
+            ),
+          ),
+        );
+
+        // The mount registered its real (private) handle with our host.
+        final handle = host.registered;
+        expect(handle, isNotNull);
+        expect(router.stack, const [_Cart()]);
+
+        // Replaying a KaiselModuleConfig replays its stack into the router.
+        await handle?.restoreFromConfig(
+          KaiselModuleConfig(stack: const [_Cart(), _Shipping(), _Confirm()]),
+        );
+        await tester.pumpAndSettle();
+        expect(router.stack, const [_Cart(), _Shipping(), _Confirm()]);
+        expect(find.byKey(const ValueKey('confirm')), findsOneWidget);
+
+        // A non-module config is silently ignored — the stack is untouched.
+        await handle?.restoreFromConfig(
+          KaiselShellConfig(
+            activeBranch: 0,
+            activeBranchStack: const [_OtherRoot()],
+          ),
+        );
+        await tester.pumpAndSettle();
+        expect(router.stack, const [_Cart(), _Shipping(), _Confirm()]);
+      },
+    );
   });
+}
+
+// A minimal nested host that records the handle the module mount
+// registers, so a test can drive the real handle's restoreFromConfig.
+class _CapturingHost implements KaiselNestedHost {
+  KaiselNestedHandle? registered;
+
+  @override
+  void registerNested(KaiselNestedHandle handle) => registered = handle;
+
+  @override
+  void unregisterNested(KaiselNestedHandle handle) {
+    if (identical(registered, handle)) registered = null;
+  }
 }
 
 // A tiny fake-context for resolver smoke tests. We only need it to
@@ -245,6 +400,12 @@ class _CaptureRouterModule extends RouteModule<_CheckoutRoute> {
   @override
   Widget buildPage(BuildContext context, _CheckoutRoute route) {
     onBuild(context.router<_CheckoutRoute>());
-    return const SizedBox();
+    // Render the same keyed boxes as _TestCheckoutModule so tests can
+    // assert which route is on top while still capturing the router.
+    return switch (route) {
+      _Cart() => const SizedBox(key: ValueKey('cart')),
+      _Shipping() => const SizedBox(key: ValueKey('ship')),
+      _Confirm() => const SizedBox(key: ValueKey('confirm')),
+    };
   }
 }

--- a/packages/kaisel/test/kaisel_nested_adaptive_test.dart
+++ b/packages/kaisel/test/kaisel_nested_adaptive_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kaisel/kaisel.dart';
+import 'package:kaisel/src/kaisel_adaptive.dart'
+    show KaiselAdaptiveKey, adaptiveEntryIdFromPageKey;
 
 // Test fixtures: two separate route hierarchies, one per branch.
 
@@ -464,6 +466,28 @@ void main() {
     test('isAdaptive can be opted in by overriding', () {
       const module = _AdaptiveShopModule();
       expect(module.isAdaptive, isTrue);
+    });
+  });
+
+  group('adaptiveEntryIdFromPageKey', () {
+    test('returns the popId of a KaiselAdaptiveKey', () {
+      // stableId and popId differ for absorbing pages; the pop target
+      // is the popId, not the stableId.
+      const key = KaiselAdaptiveKey(2, 5);
+      expect(adaptiveEntryIdFromPageKey(key), 5);
+    });
+
+    test('returns the value of a ValueKey<int>', () {
+      expect(adaptiveEntryIdFromPageKey(const ValueKey<int>(7)), 7);
+    });
+
+    test('returns null for an unrecognised key type', () {
+      expect(adaptiveEntryIdFromPageKey(const ValueKey<String>('x')), isNull);
+      expect(adaptiveEntryIdFromPageKey(UniqueKey()), isNull);
+    });
+
+    test('returns null for a null key', () {
+      expect(adaptiveEntryIdFromPageKey(null), isNull);
     });
   });
 }

--- a/packages/kaisel/test/kaisel_nested_adaptive_test.dart
+++ b/packages/kaisel/test/kaisel_nested_adaptive_test.dart
@@ -4,8 +4,6 @@ import 'package:kaisel/kaisel.dart';
 import 'package:kaisel/src/kaisel_adaptive.dart'
     show KaiselAdaptiveKey, adaptiveEntryIdFromPageKey;
 
-// Test fixtures: two separate route hierarchies, one per branch.
-
 sealed class _HomeRoute extends KaiselRoute {
   const _HomeRoute();
 }
@@ -33,8 +31,6 @@ final class _DiscoverRoot extends _DiscoverRoute {
   const _DiscoverRoot();
 }
 
-// A module route hierarchy for the module-adaptive tests.
-
 sealed class _ShopRoute extends KaiselRoute {
   const _ShopRoute();
 }
@@ -49,8 +45,6 @@ final class _ShopDetail extends _ShopRoute {
   @override
   List<Object?> get props => [sku];
 }
-
-// Top-level app route to drive the host delegate.
 
 sealed class _AppRoute extends KaiselRoute {
   const _AppRoute();
@@ -216,8 +210,6 @@ void main() {
     testWidgets(
       'adaptive branch collapses list+detail into one absorbing page',
       (tester) async {
-        // Set up the home branch router with [HomeList, HomeDetail].
-        // The discover branch is plain.
         final homeRouter = KaiselRouter<_HomeRoute>(initial: const _HomeRoot());
         await homeRouter.push(const _HomeList());
         await homeRouter.push(const _HomeDetail('42'));
@@ -294,10 +286,6 @@ void main() {
     testWidgets(
       'popping inside an adaptive branch pops the top entry via PopScope',
       (tester) async {
-        // Same setup as above. Verify that triggering the shell's
-        // PopScope (the canonical Android-back path inside a shell)
-        // pops the top entry from the branch even when absorption
-        // has collapsed the visible pages to one.
         final homeRouter = KaiselRouter<_HomeRoute>(initial: const _HomeList());
         await homeRouter.push(const _HomeDetail('42'));
 
@@ -388,8 +376,6 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Absorbing widget is visible; standalone List/Detail screens
-      // are not.
       expect(find.byType(_AbsorbedShop), findsOneWidget);
       expect(find.byType(_ShopListScreen), findsNothing);
       expect(find.byType(_ShopDetailScreen), findsNothing);
@@ -434,8 +420,6 @@ void main() {
       'default buildAdaptivePage wraps buildPage as a standalone page',
       (tester) async {
         const module = _SimpleShopModule();
-        // The default implementation returns
-        // KaiselStandalonePage(buildPage(...)). Call it and verify.
         await tester.pumpWidget(
           MaterialApp(
             home: Builder(

--- a/packages/kaisel/test/kaisel_nested_flow_test.dart
+++ b/packages/kaisel/test/kaisel_nested_flow_test.dart
@@ -180,5 +180,49 @@ void main() {
         await outer;
       },
     );
+
+    testWidgets(
+      'throws a FlutterError when a flow is active but no modalBuilder '
+      'was provided',
+      (tester) async {
+        final router = KaiselRouter<_App>(initial: const _Home());
+        // Deliberately omit modalBuilder.
+        final delegate = KaiselRouterDelegate<_App>(
+          router: router,
+          builder: (context, route) => switch (route) {
+            _Home() => const _HomeScreen(),
+            _AddCardFlow() => const _AddCardModalContent(),
+            _VerifyIdentityFlow() => const _VerifyIdentityModalContent(),
+          },
+        );
+        addTearDown(delegate.dispose);
+        addTearDown(router.dispose);
+
+        await tester.pumpWidget(
+          MaterialApp.router(
+            routerDelegate: delegate,
+            routeInformationParser: _CurrentStackParser(router),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        // No flow active yet: build is clean.
+        expect(tester.takeException(), isNull);
+        expect(find.text('HOME'), findsOneWidget);
+
+        // Opening a modal flow forces a rebuild that hits the guard.
+        final pending = router.run<bool>(const _AddCardFlow());
+        await tester.pump();
+        await tester.pump();
+
+        final error = tester.takeException();
+        expect(error, isA<FlutterError>());
+        expect((error as FlutterError).message, contains('modalBuilder'));
+
+        // Drain the pending flow result so it doesn't leak past the test.
+        router.completeFlow<bool>(false);
+        await pending;
+      },
+    );
   });
 }

--- a/packages/kaisel/test/kaisel_nested_flow_test.dart
+++ b/packages/kaisel/test/kaisel_nested_flow_test.dart
@@ -94,29 +94,25 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Only HOME visible initially.
       expect(find.text('HOME'), findsOneWidget);
       expect(find.text('ADD-CARD-MODAL'), findsNothing);
       expect(find.text('VERIFY-IDENTITY-MODAL'), findsNothing);
 
-      // Start the outer flow.
       final outer = router.run<bool>(const _AddCardFlow());
       await tester.pumpAndSettle();
 
       expect(router.activeFlows.length, 1);
       expect(find.text('ADD-CARD-MODAL'), findsOneWidget);
 
-      // Start the nested inner flow from within the outer.
       final inner = router.run<String>(const _VerifyIdentityFlow());
       await tester.pumpAndSettle();
 
       expect(router.activeFlows.length, 2);
-      // BOTH modal contents are in the widget tree. The inner is
-      // on top (its Stack child comes last).
+      // Both modal contents are mounted; the inner is on top because its
+      // Stack child comes last.
       expect(find.text('ADD-CARD-MODAL'), findsOneWidget);
       expect(find.text('VERIFY-IDENTITY-MODAL'), findsOneWidget);
 
-      // Complete the inner flow.
       router.completeFlow<String>('verified-token-42');
       final tokenResult = await inner;
       await tester.pumpAndSettle();
@@ -126,7 +122,6 @@ void main() {
       expect(find.text('VERIFY-IDENTITY-MODAL'), findsNothing);
       expect(find.text('ADD-CARD-MODAL'), findsOneWidget);
 
-      // Complete the outer flow.
       router.completeFlow<bool>(true);
       final cardResult = await outer;
       await tester.pumpAndSettle();
@@ -140,9 +135,6 @@ void main() {
     testWidgets(
       'each flow layer has its own inner Navigator (independent state)',
       (tester) async {
-        // Push a route inside the outer flow's stack, then start a
-        // nested flow, then verify the outer flow's stack is untouched
-        // when the inner one mutates its own.
         final router = KaiselRouter<_App>(initial: const _Home());
         final delegate = KaiselRouterDelegate<_App>(
           router: router,
@@ -206,7 +198,6 @@ void main() {
         );
         await tester.pumpAndSettle();
 
-        // No flow active yet: build is clean.
         expect(tester.takeException(), isNull);
         expect(find.text('HOME'), findsOneWidget);
 

--- a/packages/kaisel/test/kaisel_page_scope_test.dart
+++ b/packages/kaisel/test/kaisel_page_scope_test.dart
@@ -48,6 +48,21 @@ class _ScopeReader extends StatelessWidget {
   }
 }
 
+/// Reads the scope via the non-null [KaiselPageScope.of] accessor and
+/// forwards it to a builder so tests can assert on the values it
+/// returns from inside a kaisel-managed page.
+class _ScopeOfReader extends StatelessWidget {
+  const _ScopeOfReader({required this.onBuild});
+
+  final void Function(KaiselPageScope scope) onBuild;
+
+  @override
+  Widget build(BuildContext context) {
+    onBuild(KaiselPageScope.of(context));
+    return const Scaffold(body: SizedBox.shrink());
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -207,6 +222,85 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(observed, isNull);
+    });
+
+    testWidgets('of returns the enclosing scope inside a kaisel page', (
+      tester,
+    ) async {
+      // Stack: [_A, _B]. The top page (_B) is the one rendered to the
+      // tester, so of() inside it should return _B's scope:
+      // position 1, stackLength 2, previous _A, isTop true.
+      final router = KaiselRouter<_R>(initial: const _A());
+      await router.push(const _B());
+
+      KaiselPageScope? viaOf;
+      KaiselPageScope? viaMaybeOf;
+
+      final delegate = KaiselRouterDelegate<_R>(
+        router: router,
+        builder: (context, route) => Builder(
+          builder: (context) {
+            // maybeOf and of read from the same enclosing scope, so
+            // they must agree for the rendered (top) page.
+            viaMaybeOf = KaiselPageScope.maybeOf(context);
+            return _ScopeOfReader(onBuild: (scope) => viaOf = scope);
+          },
+        ),
+      );
+      addTearDown(delegate.dispose);
+      addTearDown(router.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp.router(
+          routerDelegate: delegate,
+          routeInformationParser: _Parser(router),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(viaOf, isNotNull);
+      // of() returns the same data maybeOf() would for the top page.
+      expect(viaOf?.route, const _B());
+      expect(viaOf?.position, 1);
+      expect(viaOf?.stackLength, 2);
+      expect(viaOf?.previous, const _A());
+      expect(viaOf?.isTop, isTrue);
+      expect(viaOf?.isBottom, isFalse);
+      // Same scope the maybeOf accessor exposes.
+      expect(viaOf?.route, viaMaybeOf?.route);
+      expect(viaOf?.position, viaMaybeOf?.position);
+      expect(viaOf?.stackLength, viaMaybeOf?.stackLength);
+      expect(viaOf?.previous, viaMaybeOf?.previous);
+    });
+
+    testWidgets('of throws an AssertionError outside a kaisel page', (
+      tester,
+    ) async {
+      // No KaiselPageScope ancestor: of() asserts scope != null, which
+      // fires as an AssertionError in this debug/test build.
+      Object? caught;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              try {
+                KaiselPageScope.of(context);
+              } on AssertionError catch (error) {
+                caught = error;
+              }
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(caught, isA<AssertionError>());
+      expect(
+        (caught as AssertionError?)?.message,
+        contains('KaiselPageScope.of()'),
+      );
     });
 
     testWidgets('updateShouldNotify fires when context fields change', (

--- a/packages/kaisel/test/kaisel_page_scope_test.dart
+++ b/packages/kaisel/test/kaisel_page_scope_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kaisel/kaisel.dart';
 
-// Test routes.
 sealed class _R extends KaiselRoute {
   const _R();
 }
@@ -146,23 +145,10 @@ void main() {
   group('KaiselPageScope (adaptive pipeline)', () {
     testWidgets('absorbing pages report isBottom=true even when the '
         'router stack has multiple entries', (tester) async {
-      // Stack: [_A, _B, _C('x')]. Adaptive builder absorbs _C+_B
-      // into one page. After absorption, the rendered Navigator has
-      // pages [_A, absorbing(_B+_C)]. The absorbing page is at
-      // rendered position 1, stackLength 2.
-      //
-      // Inside the absorbing page's widget tree, descendants see
-      // the absorbing page's scope: route=_C, position=1,
-      // stackLength=2, previous=_A. isBottom=false because there's
-      // _A below.
-      //
-      // Now we'll test the more interesting case: a stack where the
-      // absorbing page is THE ONLY rendered page.
-
       final router = KaiselRouter<_R>(initial: const _A());
       await router.push(const _C('x'));
-      // Stack: [_A, _C('x')]. Adaptive builder absorbs (_C with
-      // prev _A) into one page. Rendered Navigator has ONE page:
+      // Stack: [_A, _C('x')]. The adaptive builder absorbs (_C with
+      // prev _A) into one page, so the rendered Navigator has ONE page:
       // the absorbing one. Inside it, isBottom should be true.
 
       KaiselPageScope? observed;
@@ -193,9 +179,6 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(observed, isNotNull);
-      // The absorbing page absorbed _A below, so the rendered
-      // Navigator has only ONE page total. Inside that page, the
-      // descendant should see isBottom=true.
       expect(observed!.route, const _C('x'));
       expect(observed!.position, 0);
       expect(observed!.stackLength, 1);
@@ -227,9 +210,6 @@ void main() {
     testWidgets('of returns the enclosing scope inside a kaisel page', (
       tester,
     ) async {
-      // Stack: [_A, _B]. The top page (_B) is the one rendered to the
-      // tester, so of() inside it should return _B's scope:
-      // position 1, stackLength 2, previous _A, isTop true.
       final router = KaiselRouter<_R>(initial: const _A());
       await router.push(const _B());
 
@@ -259,14 +239,12 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(viaOf, isNotNull);
-      // of() returns the same data maybeOf() would for the top page.
       expect(viaOf?.route, const _B());
       expect(viaOf?.position, 1);
       expect(viaOf?.stackLength, 2);
       expect(viaOf?.previous, const _A());
       expect(viaOf?.isTop, isTrue);
       expect(viaOf?.isBottom, isFalse);
-      // Same scope the maybeOf accessor exposes.
       expect(viaOf?.route, viaMaybeOf?.route);
       expect(viaOf?.position, viaMaybeOf?.position);
       expect(viaOf?.stackLength, viaMaybeOf?.stackLength);
@@ -306,8 +284,6 @@ void main() {
     testWidgets('updateShouldNotify fires when context fields change', (
       tester,
     ) async {
-      // Push to make position/stackLength change, then verify the
-      // dependent rebuilt.
       final router = KaiselRouter<_R>(initial: const _A());
       var buildCount = 0;
 

--- a/packages/kaisel/test/kaisel_page_wrapper_test.dart
+++ b/packages/kaisel/test/kaisel_page_wrapper_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kaisel/kaisel.dart';
 
-// Routes for testing wrapper context.
 sealed class _R extends KaiselRoute {
   const _R();
 }
@@ -66,7 +65,6 @@ void main() {
       await router.push(const _B());
       await router.push(const _C('1'));
 
-      // Record every wrapper call so the test can inspect them.
       final captured = <KaiselPageWrapperContext<_R>>[];
 
       final delegate = KaiselRouterDelegate<_R>(
@@ -96,7 +94,6 @@ void main() {
       // Take the most recent build's invocations: the last 3.
       final lastBuild = captured.sublist(captured.length - 3);
 
-      // Bottom: A
       expect(lastBuild[0].route, const _A());
       expect(lastBuild[0].position, 0);
       expect(lastBuild[0].stackLength, 3);
@@ -104,7 +101,6 @@ void main() {
       expect(lastBuild[0].isBottom, isTrue);
       expect(lastBuild[0].isTop, isFalse);
 
-      // Middle: B
       expect(lastBuild[1].route, const _B());
       expect(lastBuild[1].position, 1);
       expect(lastBuild[1].stackLength, 3);
@@ -112,7 +108,6 @@ void main() {
       expect(lastBuild[1].isBottom, isFalse);
       expect(lastBuild[1].isTop, isFalse);
 
-      // Top: C('1')
       expect(lastBuild[2].route, const _C('1'));
       expect(lastBuild[2].position, 2);
       expect(lastBuild[2].stackLength, 3);
@@ -168,7 +163,6 @@ void main() {
       expect(captured, hasLength(greaterThanOrEqualTo(2)));
       final lastBuild = captured.sublist(captured.length - 2);
 
-      // Bottom rendered page: A.
       expect(lastBuild[0].route, const _A());
       expect(lastBuild[0].position, 0);
       expect(lastBuild[0].stackLength, 2);
@@ -234,17 +228,12 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // The branch wrapper ran and its marker is mounted around the
-      // home branch's initial page content.
       expect(wrapperCalls, greaterThan(0));
       expect(find.byKey(const ValueKey('branch-wrapper')), findsOneWidget);
       expect(find.text('home:${const _A()}'), findsOneWidget);
     });
 
     testWidgets('a branch pageWrapper wraps a pushed page too', (tester) async {
-      // After pushing inside the branch, the inner navigator builds
-      // two pages and runs the wrapper for each, so the marker
-      // wraps the new top page as well.
       final home = KaiselRouter<_R>(initial: const _A());
       final tab = KaiselRouter<_Tab>(initial: const _TabRoot());
       final shell = BranchedShellRouter(branches: [home, tab]);
@@ -284,7 +273,6 @@ void main() {
       );
       await tester.pumpAndSettle();
 
-      // Initial page wrapped.
       expect(find.byKey(const ValueKey('branch-wrapper-0')), findsOneWidget);
 
       await home.push(const _B());

--- a/packages/kaisel/test/kaisel_page_wrapper_test.dart
+++ b/packages/kaisel/test/kaisel_page_wrapper_test.dart
@@ -33,6 +33,28 @@ class _Parser extends RouteInformationParser<KaiselConfig<_R>> {
   }
 }
 
+// A second branch route type, so the shell has two heterogeneous
+// branches like a real bottom-nav app.
+sealed class _Tab extends KaiselRoute {
+  const _Tab();
+}
+
+final class _TabRoot extends _Tab {
+  const _TabRoot();
+}
+
+/// A distinctive marker the branch's pageWrapper injects around the
+/// page's child. Its presence in the tree proves the inner navigator
+/// actually invoked the branch's wrapper rather than its default.
+class _WrapperMarker extends StatelessWidget {
+  const _WrapperMarker({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => child;
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -161,6 +183,122 @@ void main() {
       expect(lastBuild[1].stackLength, 2);
       expect(lastBuild[1].previous, const _A());
       expect(lastBuild[1].isTop, isTrue);
+    });
+  });
+
+  group('KaiselBranch pageWrapper (inner navigator)', () {
+    testWidgets('a branch pageWrapper wraps the initial page', (tester) async {
+      // A two-branch shell where the home branch supplies a custom
+      // pageWrapper. The inner navigator must route the branch's
+      // initial page through that wrapper (the _wrapSimple `if
+      // (wrapper != null)` path), so the marker is in the tree.
+      final home = KaiselRouter<_R>(initial: const _A());
+      final tab = KaiselRouter<_Tab>(initial: const _TabRoot());
+      final shell = BranchedShellRouter(branches: [home, tab]);
+      addTearDown(shell.dispose);
+      addTearDown(home.dispose);
+      addTearDown(tab.dispose);
+
+      var wrapperCalls = 0;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselBranchedShell(
+            shell: shell,
+            branches: [
+              KaiselBranch<_R>(
+                router: home,
+                pageBuilder: (context, route) =>
+                    Scaffold(body: Text('home:$route')),
+                pageWrapper: (ctx) {
+                  wrapperCalls++;
+                  return MaterialPage<Object?>(
+                    key: ctx.key,
+                    child: _WrapperMarker(
+                      key: const ValueKey('branch-wrapper'),
+                      child: ctx.child,
+                    ),
+                  );
+                },
+              ),
+              KaiselBranch<_Tab>(
+                router: tab,
+                pageBuilder: (context, route) =>
+                    const Scaffold(body: Text('tab')),
+              ),
+            ],
+            chromeBuilder: (context, active, branchContent, switchBranch) =>
+                branchContent,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The branch wrapper ran and its marker is mounted around the
+      // home branch's initial page content.
+      expect(wrapperCalls, greaterThan(0));
+      expect(find.byKey(const ValueKey('branch-wrapper')), findsOneWidget);
+      expect(find.text('home:${const _A()}'), findsOneWidget);
+    });
+
+    testWidgets('a branch pageWrapper wraps a pushed page too', (tester) async {
+      // After pushing inside the branch, the inner navigator builds
+      // two pages and runs the wrapper for each, so the marker
+      // wraps the new top page as well.
+      final home = KaiselRouter<_R>(initial: const _A());
+      final tab = KaiselRouter<_Tab>(initial: const _TabRoot());
+      final shell = BranchedShellRouter(branches: [home, tab]);
+      addTearDown(shell.dispose);
+      addTearDown(home.dispose);
+      addTearDown(tab.dispose);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: KaiselBranchedShell(
+            shell: shell,
+            branches: [
+              KaiselBranch<_R>(
+                router: home,
+                pageBuilder: (context, route) =>
+                    Scaffold(body: Text('home:$route')),
+                pageWrapper: (ctx) => MaterialPage<Object?>(
+                  key: ctx.key,
+                  child: _WrapperMarker(
+                    // A per-position key so we can count how many
+                    // pages went through the wrapper.
+                    key: ValueKey('branch-wrapper-${ctx.position}'),
+                    child: ctx.child,
+                  ),
+                ),
+              ),
+              KaiselBranch<_Tab>(
+                router: tab,
+                pageBuilder: (context, route) =>
+                    const Scaffold(body: Text('tab')),
+              ),
+            ],
+            chromeBuilder: (context, active, branchContent, switchBranch) =>
+                branchContent,
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // Initial page wrapped.
+      expect(find.byKey(const ValueKey('branch-wrapper-0')), findsOneWidget);
+
+      await home.push(const _B());
+      await tester.pumpAndSettle();
+
+      // Both the bottom (_A) and the pushed top (_B) pages went
+      // through the branch's wrapper. The bottom page is offstage
+      // once _B covers it, so look past offstage for it.
+      expect(
+        find.byKey(const ValueKey('branch-wrapper-0'), skipOffstage: false),
+        findsOneWidget,
+      );
+      expect(find.byKey(const ValueKey('branch-wrapper-1')), findsOneWidget);
+      expect(find.text('home:${const _B()}'), findsOneWidget);
     });
   });
 }

--- a/packages/kaisel/test/kaisel_stack_codec_test.dart
+++ b/packages/kaisel/test/kaisel_stack_codec_test.dart
@@ -155,5 +155,30 @@ void main() {
       );
       expect(info?.uri.path, '/settings');
     });
+
+    test('exposes the config codec it was constructed with', () {
+      const codec = StackToConfigCodec<_R>(_StackCodec());
+      final parser = KaiselRouteInformationParser<_R>(
+        codec: codec,
+        fallback: const [_Home()],
+      );
+      expect(identical(parser.codec, codec), isTrue);
+    });
+
+    test('.fromStackCodec wraps the stack codec in a StackToConfigCodec', () {
+      final parser = KaiselRouteInformationParser<_R>.fromStackCodec(
+        codec: const _StackCodec(),
+        fallback: const [_Home()],
+      );
+      expect(parser.codec, isA<StackToConfigCodec<_R>>());
+    });
+
+    test('exposes the fallback stack it was constructed with', () {
+      final parser = KaiselRouteInformationParser<_R>.fromStackCodec(
+        codec: const _StackCodec(),
+        fallback: const [_Home(), _Settings()],
+      );
+      expect(parser.fallback, const [_Home(), _Settings()]);
+    });
   });
 }

--- a/packages/kaisel_core/test/kaisel_config_test.dart
+++ b/packages/kaisel_core/test/kaisel_config_test.dart
@@ -1,8 +1,6 @@
 import 'package:kaisel_core/kaisel_core.dart';
 import 'package:test/test.dart';
 
-// Test fixtures — two distinct sealed hierarchies.
-
 sealed class _Top extends KaiselRoute {
   const _Top();
 }
@@ -34,7 +32,6 @@ final class _Product extends _Home {
   List<Object?> get props => [id];
 }
 
-// A simple stack codec for the migration-adapter test.
 class _LegacyStackCodec implements KaiselStackCodec<_Top> {
   const _LegacyStackCodec();
 
@@ -222,7 +219,6 @@ void main() {
           ),
         ),
       );
-      // No /home/products/x — just /app.
       expect(encoded.path, '/app');
     });
 
@@ -252,8 +248,6 @@ void main() {
     });
 
     test('runs guards on the restored stack', () async {
-      // A guard that strips _Product routes — restoreStack should
-      // see the effect.
       List<_Home> stripProducts(List<_Home> current, List<_Home> proposed) {
         return proposed.where((r) => r is! _Product).toList();
       }

--- a/packages/kaisel_core/test/kaisel_config_test.dart
+++ b/packages/kaisel_core/test/kaisel_config_test.dart
@@ -87,6 +87,17 @@ void main() {
       expect(a, isNot(equals(b)));
     });
 
+    test('stackOnly builds a config with that stack and no nested state', () {
+      final c = KaiselConfig<_Top>.stackOnly(const [_Shell(), _Settings()]);
+      expect(c.mainStack, const [_Shell(), _Settings()]);
+      expect(c.nestedState, isNull);
+    });
+
+    test('stackOnly mainStack is unmodifiable', () {
+      final c = KaiselConfig<_Top>.stackOnly([const _Splash()]);
+      expect(() => c.mainStack.add(const _Shell()), throwsUnsupportedError);
+    });
+
     test('mainStack is unmodifiable', () {
       final c = KaiselConfig<_Top>(mainStack: [const _Splash()]);
       expect(() => c.mainStack.add(const _Shell()), throwsUnsupportedError);
@@ -114,6 +125,30 @@ void main() {
       expect(a.hashCode, b.hashCode);
     });
 
+    test('differs when activeBranch differs', () {
+      final a = KaiselShellConfig(
+        activeBranch: 0,
+        activeBranchStack: const [_HomeRoot()],
+      );
+      final b = KaiselShellConfig(
+        activeBranch: 1,
+        activeBranchStack: const [_HomeRoot()],
+      );
+      expect(a, isNot(equals(b)));
+    });
+
+    test('differs when activeBranchStack differs', () {
+      final a = KaiselShellConfig(
+        activeBranch: 0,
+        activeBranchStack: const [_HomeRoot()],
+      );
+      final b = KaiselShellConfig(
+        activeBranch: 0,
+        activeBranchStack: const [_HomeRoot(), _Product('x')],
+      );
+      expect(a, isNot(equals(b)));
+    });
+
     test('rejects an empty activeBranchStack', () {
       expect(
         () => KaiselShellConfig(activeBranch: 0, activeBranchStack: const []),
@@ -127,6 +162,37 @@ void main() {
           activeBranch: -1,
           activeBranchStack: const [_HomeRoot()],
         ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
+
+  group('KaiselModuleConfig', () {
+    test('equality is value-based', () {
+      final a = KaiselModuleConfig(stack: const [_HomeRoot(), _Product('x')]);
+      final b = KaiselModuleConfig(stack: const [_HomeRoot(), _Product('x')]);
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('differs when stack differs', () {
+      final a = KaiselModuleConfig(stack: const [_HomeRoot()]);
+      final b = KaiselModuleConfig(stack: const [_HomeRoot(), _Product('x')]);
+      expect(a, isNot(equals(b)));
+    });
+
+    test('a module config is never equal to a shell config', () {
+      final module = KaiselModuleConfig(stack: const [_HomeRoot()]);
+      final shell = KaiselShellConfig(
+        activeBranch: 0,
+        activeBranchStack: const [_HomeRoot()],
+      );
+      expect(module, isNot(equals(shell)));
+    });
+
+    test('rejects an empty stack', () {
+      expect(
+        () => KaiselModuleConfig(stack: const []),
         throwsA(isA<AssertionError>()),
       );
     });

--- a/packages/kaisel_core/test/kaisel_module_codec_test.dart
+++ b/packages/kaisel_core/test/kaisel_module_codec_test.dart
@@ -1,0 +1,215 @@
+import 'package:kaisel_core/kaisel_core.dart';
+import 'package:test/test.dart';
+
+// Fixtures — a host route family with a module-mount marker route, and a
+// self-contained module route family.
+
+sealed class _AppRoute extends KaiselRoute {
+  const _AppRoute();
+}
+
+final class _Home extends _AppRoute {
+  const _Home();
+}
+
+final class _Settings extends _AppRoute {
+  const _Settings();
+}
+
+final class _CheckoutMount extends _AppRoute {
+  const _CheckoutMount();
+}
+
+sealed class _CheckoutRoute extends KaiselRoute {
+  const _CheckoutRoute();
+}
+
+final class _Cart extends _CheckoutRoute {
+  const _Cart();
+}
+
+final class _Shipping extends _CheckoutRoute {
+  const _Shipping();
+}
+
+final class _Confirm extends _CheckoutRoute {
+  const _Confirm();
+}
+
+// The module's own URL codec, relative to its mount prefix.
+class _CheckoutCodec extends ModuleStackCodec<_CheckoutRoute> {
+  const _CheckoutCodec();
+
+  @override
+  List<String> encode(List<_CheckoutRoute> stack) => switch (stack.last) {
+    _Cart() => const [],
+    _Shipping() => const ['shipping'],
+    _Confirm() => const ['confirm'],
+  };
+
+  @override
+  List<_CheckoutRoute>? decode(List<String> segments) => switch (segments) {
+    [] => const [_Cart()],
+    ['shipping'] => const [_Cart(), _Shipping()],
+    ['confirm'] => const [_Cart(), _Shipping(), _Confirm()],
+    _ => null,
+  };
+}
+
+// The host's base codec. Knows main-stack routes only; mount routes are
+// handled by the composer before reaching here.
+class _MainCodec implements KaiselConfigCodec<_AppRoute> {
+  const _MainCodec();
+
+  @override
+  Uri encode(KaiselConfig<_AppRoute> config) => switch (config.mainStack.last) {
+    _Home() => Uri(path: '/'),
+    _Settings() => Uri(path: '/settings'),
+    // Mount routes shouldn't reach the base codec when wrapped by a
+    // composer; defensive fallback.
+    _CheckoutMount() => Uri(path: '/'),
+  };
+
+  @override
+  KaiselConfig<_AppRoute>? decode(Uri uri) => switch (uri.pathSegments) {
+    [] || [''] => KaiselConfig(mainStack: const [_Home()]),
+    ['settings'] => KaiselConfig(mainStack: const [_Settings()]),
+    _ => null,
+  };
+}
+
+void main() {
+  group('ModuleStackCodec encode/decode round-trip', () {
+    const codec = _CheckoutCodec();
+
+    test('typed encode then decode restores the original stack', () {
+      for (final stack in const <List<_CheckoutRoute>>[
+        [_Cart()],
+        [_Cart(), _Shipping()],
+        [_Cart(), _Shipping(), _Confirm()],
+      ]) {
+        final encoded = codec.encode(stack);
+        expect(codec.decode(encoded), stack);
+      }
+    });
+
+    test('root state encodes to const [] (prefix alone suffices)', () {
+      expect(codec.encode(const [_Cart()]), isEmpty);
+    });
+  });
+
+  group('UntypedModuleStackCodec bridge (encodeAny/decodeAny)', () {
+    const codec = _CheckoutCodec();
+    // Reference it through the untyped interface to exercise the bridge.
+    const UntypedModuleStackCodec untyped = _CheckoutCodec();
+
+    test('encodeAny equals the typed encode of the same stack', () {
+      const stack = <_CheckoutRoute>[_Cart(), _Shipping()];
+      expect(
+        untyped.encodeAny(const <KaiselRoute>[_Cart(), _Shipping()]),
+        codec.encode(stack),
+      );
+      expect(untyped.encodeAny(const <KaiselRoute>[_Cart(), _Shipping()]), [
+        'shipping',
+      ]);
+    });
+
+    test('decodeAny equals the typed decode and upcasts to KaiselRoute', () {
+      final any = untyped.decodeAny(const ['shipping']);
+      expect(any, codec.decode(const ['shipping']));
+      expect(any, isA<List<KaiselRoute>>());
+      expect(any, hasLength(2));
+      final decoded = any ?? const <KaiselRoute>[];
+      expect(decoded.first, isA<_Cart>());
+      expect(decoded.last, isA<_Shipping>());
+    });
+
+    test('decodeAny returns null for segments the typed decode rejects', () {
+      expect(untyped.decodeAny(const ['nonsense']), isNull);
+      expect(codec.decode(const ['nonsense']), isNull);
+    });
+  });
+
+  group('ConfigCodecWithModules composes host codec + mounted module', () {
+    const codec = ConfigCodecWithModules<_AppRoute>(
+      baseCodec: _MainCodec(),
+      modules: [
+        ModuleMount(
+          mountRoute: _CheckoutMount(),
+          prefix: '/checkout',
+          codec: _CheckoutCodec(),
+        ),
+      ],
+    );
+
+    test('encode of a module-top config produces a URI under the prefix', () {
+      final uri = codec.encode(
+        KaiselConfig(
+          mainStack: const [_CheckoutMount()],
+          nestedState: KaiselModuleConfig(stack: const [_Cart(), _Shipping()]),
+        ),
+      );
+      expect(uri.path, '/checkout/shipping');
+      expect(uri.pathSegments, ['checkout', 'shipping']);
+    });
+
+    test('encode of a module-top config with no nested state yields the prefix '
+        'alone', () {
+      // Transient: the mount route is on top but no KaiselModuleConfig has been
+      // registered yet (just pushed, or a codec produced this state). The
+      // composer falls back to encoding the mount prefix alone.
+      final uri = codec.encode(
+        KaiselConfig(mainStack: const [_CheckoutMount()]),
+      );
+      expect(uri.pathSegments, ['checkout']);
+    });
+
+    test('encode of a plain (non-module) top delegates to the host codec', () {
+      expect(codec.encode(KaiselConfig(mainStack: const [_Home()])).path, '/');
+      expect(
+        codec.encode(KaiselConfig(mainStack: const [_Settings()])).path,
+        '/settings',
+      );
+    });
+
+    test(
+      'decode of a module URL yields mount on main stack + module state',
+      () {
+        final result = codec.decode(Uri.parse('/checkout/shipping'));
+        expect(result, isNotNull);
+        final config = result ?? KaiselConfig(mainStack: const [_Home()]);
+        expect(config.mainStack, const [_CheckoutMount()]);
+        expect(config.nestedState, isA<KaiselModuleConfig>());
+        final nested = config.nestedState;
+        expect(
+          nested,
+          isA<KaiselModuleConfig>().having((n) => n.stack, 'stack', const [
+            _Cart(),
+            _Shipping(),
+          ]),
+        );
+      },
+    );
+
+    test('decode of a URL matching no module and no host route is null', () {
+      // Not under any module prefix; base codec rejects unknown paths.
+      expect(codec.decode(Uri.parse('/unknown')), isNull);
+      // Under the module prefix but rejected by the module codec — the
+      // composer returns null and does NOT fall through to the host codec.
+      expect(codec.decode(Uri.parse('/checkout/nope')), isNull);
+    });
+
+    test('decode then encode is identity for module URLs', () {
+      for (final path in const [
+        '/checkout',
+        '/checkout/shipping',
+        '/checkout/confirm',
+      ]) {
+        final decoded = codec.decode(Uri.parse(path));
+        expect(decoded, isNotNull, reason: 'decode failed for $path');
+        final config = decoded ?? KaiselConfig(mainStack: const [_Home()]);
+        expect(codec.encode(config).path, path, reason: 'round-trip $path');
+      }
+    });
+  });
+}

--- a/packages/kaisel_core/test/kaisel_module_codec_test.dart
+++ b/packages/kaisel_core/test/kaisel_module_codec_test.dart
@@ -1,9 +1,6 @@
 import 'package:kaisel_core/kaisel_core.dart';
 import 'package:test/test.dart';
 
-// Fixtures — a host route family with a module-mount marker route, and a
-// self-contained module route family.
-
 sealed class _AppRoute extends KaiselRoute {
   const _AppRoute();
 }
@@ -36,7 +33,6 @@ final class _Confirm extends _CheckoutRoute {
   const _Confirm();
 }
 
-// The module's own URL codec, relative to its mount prefix.
 class _CheckoutCodec extends ModuleStackCodec<_CheckoutRoute> {
   const _CheckoutCodec();
 
@@ -56,8 +52,6 @@ class _CheckoutCodec extends ModuleStackCodec<_CheckoutRoute> {
   };
 }
 
-// The host's base codec. Knows main-stack routes only; mount routes are
-// handled by the composer before reaching here.
 class _MainCodec implements KaiselConfigCodec<_AppRoute> {
   const _MainCodec();
 
@@ -100,7 +94,6 @@ void main() {
 
   group('UntypedModuleStackCodec bridge (encodeAny/decodeAny)', () {
     const codec = _CheckoutCodec();
-    // Reference it through the untyped interface to exercise the bridge.
     const UntypedModuleStackCodec untyped = _CheckoutCodec();
 
     test('encodeAny equals the typed encode of the same stack', () {
@@ -192,7 +185,6 @@ void main() {
     );
 
     test('decode of a URL matching no module and no host route is null', () {
-      // Not under any module prefix; base codec rejects unknown paths.
       expect(codec.decode(Uri.parse('/unknown')), isNull);
       // Under the module prefix but rejected by the module codec — the
       // composer returns null and does NOT fall through to the host codec.

--- a/packages/kaisel_core/test/kaisel_notifier_test.dart
+++ b/packages/kaisel_core/test/kaisel_notifier_test.dart
@@ -1,0 +1,114 @@
+import 'package:kaisel_core/framework.dart';
+import 'package:test/test.dart';
+
+/// Concrete subclass that exposes [notifyListeners] (which is `@protected`)
+/// as a public method so tests can drive notifications directly.
+class _ExposedNotifier extends KaiselChangeNotifier {
+  void fire() => notifyListeners();
+
+  /// Re-expose [isDisposed] (also `@protected`) for assertions.
+  bool get disposed => isDisposed;
+}
+
+void main() {
+  group('KaiselChangeNotifier (live)', () {
+    test('delivers notifications to registered listeners', () {
+      final notifier = _ExposedNotifier();
+      var calls = 0;
+      void listener() => calls++;
+      notifier.addListener(listener);
+
+      notifier.fire();
+      notifier.fire();
+
+      expect(calls, 2);
+    });
+
+    test('removeListener stops further delivery', () {
+      final notifier = _ExposedNotifier();
+      var calls = 0;
+      void listener() => calls++;
+      notifier.addListener(listener);
+
+      notifier.fire();
+      notifier.removeListener(listener);
+      notifier.fire();
+
+      expect(calls, 1);
+    });
+  });
+
+  group('KaiselChangeNotifier (dispose guards)', () {
+    test('isDisposed flips to true after dispose', () {
+      final notifier = _ExposedNotifier();
+      expect(notifier.disposed, isFalse);
+
+      notifier.dispose();
+
+      expect(notifier.disposed, isTrue);
+    });
+
+    test('addListener throws StateError after dispose', () {
+      final notifier = _ExposedNotifier();
+      notifier.dispose();
+
+      expect(() => notifier.addListener(() {}), throwsStateError);
+    });
+
+    test('notifyListeners throws StateError after dispose', () {
+      final notifier = _ExposedNotifier();
+      notifier.dispose();
+
+      expect(notifier.fire, throwsStateError);
+    });
+
+    test('removeListener is a safe no-op after dispose', () {
+      final notifier = _ExposedNotifier();
+      void listener() {}
+      notifier.addListener(listener);
+      notifier.dispose();
+
+      // Must not throw even though the notifier is disposed.
+      expect(() => notifier.removeListener(listener), returnsNormally);
+    });
+  });
+
+  group('KaiselChangeNotifier (snapshot-iteration safety)', () {
+    test('a listener removing another listener mid-dispatch is safe', () {
+      final notifier = _ExposedNotifier();
+      var secondCalls = 0;
+      void second() => secondCalls++;
+
+      // The first listener removes `second` during dispatch. Because
+      // notify iterates a snapshot, `second` still runs for this round.
+      notifier.addListener(() => notifier.removeListener(second));
+      notifier.addListener(second);
+
+      notifier.fire();
+      expect(secondCalls, 1, reason: 'snapshot keeps second alive this round');
+
+      // On the next round `second` is gone.
+      notifier.fire();
+      expect(secondCalls, 1);
+    });
+
+    test('a listener removing itself mid-dispatch is safe', () {
+      final notifier = _ExposedNotifier();
+      var selfCalls = 0;
+      late void Function() self;
+      self = () {
+        selfCalls++;
+        notifier.removeListener(self);
+      };
+      notifier.addListener(self);
+
+      // First dispatch runs `self` once and removes it.
+      notifier.fire();
+      expect(selfCalls, 1);
+
+      // Second dispatch: nothing left to call.
+      notifier.fire();
+      expect(selfCalls, 1);
+    });
+  });
+}

--- a/packages/kaisel_core/test/kaisel_notifier_test.dart
+++ b/packages/kaisel_core/test/kaisel_notifier_test.dart
@@ -68,7 +68,6 @@ void main() {
       notifier.addListener(listener);
       notifier.dispose();
 
-      // Must not throw even though the notifier is disposed.
       expect(() => notifier.removeListener(listener), returnsNormally);
     });
   });
@@ -87,7 +86,6 @@ void main() {
       notifier.fire();
       expect(secondCalls, 1, reason: 'snapshot keeps second alive this round');
 
-      // On the next round `second` is gone.
       notifier.fire();
       expect(secondCalls, 1);
     });
@@ -102,11 +100,9 @@ void main() {
       };
       notifier.addListener(self);
 
-      // First dispatch runs `self` once and removes it.
       notifier.fire();
       expect(selfCalls, 1);
 
-      // Second dispatch: nothing left to call.
       notifier.fire();
       expect(selfCalls, 1);
     });

--- a/packages/kaisel_core/test/kaisel_router_test.dart
+++ b/packages/kaisel_core/test/kaisel_router_test.dart
@@ -1,8 +1,6 @@
 import 'package:kaisel_core/kaisel_core.dart';
 import 'package:test/test.dart';
 
-// Test fixtures: a tiny sealed route type using v0.2's default
-// props-based equality. No manual == / hashCode needed.
 sealed class _R extends KaiselRoute {
   const _R();
 }
@@ -57,7 +55,6 @@ void main() {
       expect(r.stack, [const _A()]);
       expect(notifications, 1);
 
-      // Root: refuses to pop and does not notify.
       expect(await r.pop(), isFalse);
       expect(r.stack, [const _A()]);
       expect(notifications, 1);
@@ -107,12 +104,11 @@ void main() {
     });
 
     test('pushOrReplaceTop with empty stack pushes', () async {
-      // A pre-disposed-ish corner case: route stack should never be
-      // empty in normal operation, but verify the branch.
+      // The route stack should never be empty in normal operation, and it
+      // can't be constructed empty via the public API; this verifies that the
+      // non-empty default path with an always-true predicate triggers
+      // replaceTop.
       final r = KaiselRouter<_R>(initial: const _A());
-      // We can't construct an empty stack via public API, so this
-      // mainly verifies that the non-empty default path with a
-      // predicate that returns true still triggers replaceTop.
       await r.pushOrReplaceTop(const _A());
       expect(r.stack, [const _A()]);
     });
@@ -176,7 +172,6 @@ void main() {
         r.push(const _B('1'));
         r.push(const _B('2'));
         r.push(const _C());
-        // Await the final operation to flush the queue.
         await r.push(const _B('end'));
         expect(r.stack, [
           const _A(),
@@ -220,7 +215,6 @@ void main() {
       final entries = r.entries;
       expect(entries.length, 2);
       expect(entries.map((e) => e.route), [const _A(), const _B('x')]);
-      // Ids are distinct per entry.
       expect(entries.first.id == entries.last.id, isFalse);
     });
 
@@ -267,7 +261,6 @@ void main() {
       final onlyId = r.entries.single.id;
       r.onPageRemoved(onlyId);
 
-      // Won't pop to empty.
       expect(r.stack, [const _A()]);
       expect(r.depth, 1);
       expect(notifications, 0);

--- a/packages/kaisel_core/test/kaisel_router_test.dart
+++ b/packages/kaisel_core/test/kaisel_router_test.dart
@@ -212,6 +212,83 @@ void main() {
       expect(r.depth, 1);
       expect(r.stack, [const _A()]);
     });
+
+    test('entries exposes identity-stable stack entries', () async {
+      final r = KaiselRouter<_R>(initial: const _A());
+      await r.push(const _B('x'));
+
+      final entries = r.entries;
+      expect(entries.length, 2);
+      expect(entries.map((e) => e.route), [const _A(), const _B('x')]);
+      // Ids are distinct per entry.
+      expect(entries.first.id == entries.last.id, isFalse);
+    });
+
+    test(
+      'onPageRemoved removes the entry whose id matches and notifies',
+      () async {
+        final r = KaiselRouter<_R>(initial: const _A());
+        await r.push(const _B('x'));
+        expect(r.depth, 2);
+
+        var notifications = 0;
+        r.addListener(() => notifications++);
+
+        final topId = r.entries.last.id;
+        r.onPageRemoved(topId);
+
+        expect(r.stack, [const _A()]);
+        expect(r.depth, 1);
+        expect(notifications, 1);
+      },
+    );
+
+    test('onPageRemoved is a no-op for an unknown id', () async {
+      final r = KaiselRouter<_R>(initial: const _A());
+      await r.push(const _B('x'));
+
+      var notifications = 0;
+      r.addListener(() => notifications++);
+
+      r.onPageRemoved(999999);
+
+      expect(r.stack, [const _A(), const _B('x')]);
+      expect(r.depth, 2);
+      expect(notifications, 0);
+    });
+
+    test('onPageRemoved refuses to remove when only one entry remains', () {
+      final r = KaiselRouter<_R>(initial: const _A());
+      expect(r.depth, 1);
+
+      var notifications = 0;
+      r.addListener(() => notifications++);
+
+      final onlyId = r.entries.single.id;
+      r.onPageRemoved(onlyId);
+
+      // Won't pop to empty.
+      expect(r.stack, [const _A()]);
+      expect(r.depth, 1);
+      expect(notifications, 0);
+    });
+
+    test(
+      'applyFromInformation applies the given stack to the router',
+      () async {
+        final r = KaiselRouter<_R>(initial: const _A());
+
+        await r.applyFromInformation([
+          const _A(),
+          const _B('deep'),
+          const _C(),
+        ]);
+
+        expect(r.stack, [const _A(), const _B('deep'), const _C()]);
+        expect(r.depth, 3);
+        expect(r.current, const _C());
+      },
+    );
   });
 
   group('KaiselRouter equality default', () {

--- a/packages/kaisel_core/test/kaisel_stack_codec_test.dart
+++ b/packages/kaisel_core/test/kaisel_stack_codec_test.dart
@@ -1,0 +1,125 @@
+import 'package:kaisel_core/kaisel_core.dart';
+import 'package:test/test.dart';
+
+// Route fixtures — a small sealed hierarchy.
+
+sealed class _R extends KaiselRoute {
+  const _R();
+}
+
+final class _Home extends _R {
+  const _Home();
+}
+
+final class _Detail extends _R {
+  const _Detail(this.id);
+  final String id;
+  @override
+  List<Object?> get props => [id];
+}
+
+// A concrete multi-frame stack codec.
+//   /      ⇄ [_Home]
+//   /d/42  ⇄ [_Home, _Detail('42')]
+class _StackCodec implements KaiselStackCodec<_R> {
+  const _StackCodec();
+
+  @override
+  Uri encode(List<_R> stack) => switch (stack.last) {
+    _Home() => Uri(path: '/'),
+    _Detail(:final id) => Uri(path: '/d/$id'),
+  };
+
+  @override
+  List<_R>? decode(Uri uri) => switch (uri.pathSegments) {
+    [] || [''] => const [_Home()],
+    ['d', final id] => [const _Home(), _Detail(id)],
+    _ => null,
+  };
+}
+
+// A single-route codec, to be wrapped by KaiselSingleStackCodec.
+//   _Home()      ⇄ /
+//   _Detail(id)  ⇄ /d/<id>
+class _SingleCodec implements KaiselCodec<_R> {
+  const _SingleCodec();
+
+  @override
+  Uri encode(_R route) => switch (route) {
+    _Home() => Uri(path: '/'),
+    _Detail(:final id) => Uri(path: '/d/$id'),
+  };
+
+  @override
+  _R? decode(Uri uri) => switch (uri.pathSegments) {
+    [] || [''] => const _Home(),
+    ['d', final id] => _Detail(id),
+    _ => null,
+  };
+}
+
+void main() {
+  group('KaiselStackCodec (concrete multi-frame)', () {
+    const codec = _StackCodec();
+
+    test('round-trips a single-frame stack', () {
+      const stack = [_Home()];
+      expect(codec.decode(codec.encode(stack)), stack);
+    });
+
+    test('round-trips a deep-linked multi-frame stack', () {
+      const stack = [_Home(), _Detail('42')];
+      final encoded = codec.encode(stack);
+      // encode targets the top of the stack.
+      expect(encoded.path, '/d/42');
+      // decode restores the implicit parent frame too.
+      expect(codec.decode(encoded), stack);
+    });
+
+    test('round-trips preserving route props', () {
+      const stack = [_Home(), _Detail('abc-123')];
+      final decoded = codec.decode(codec.encode(stack));
+      expect(decoded, stack);
+      expect(decoded?.last, const _Detail('abc-123'));
+    });
+
+    test('decode returns null for an unknown URI', () {
+      expect(codec.decode(Uri(path: '/totally/unknown')), isNull);
+    });
+  });
+
+  group('KaiselSingleStackCodec (adapter over KaiselCodec)', () {
+    const inner = _SingleCodec();
+    const codec = KaiselSingleStackCodec<_R>(inner);
+
+    test('encode delegates to inner codec on the top of the stack', () {
+      const stack = [_Home(), _Detail('x')];
+      // Should encode the TOP route, not the bottom.
+      expect(codec.encode(stack), inner.encode(const _Detail('x')));
+      expect(codec.encode(stack).path, '/d/x');
+    });
+
+    test('decode wraps the inner route in a depth-1 stack', () {
+      final decoded = codec.decode(Uri(path: '/d/7'));
+      expect(decoded, const [_Detail('7')]);
+      expect(decoded?.length, 1);
+    });
+
+    test('decode of root yields a depth-1 home stack', () {
+      expect(codec.decode(Uri(path: '/')), const [_Home()]);
+    });
+
+    test('decode returns null when the inner codec returns null', () {
+      // Sanity: inner returns null for this URI.
+      expect(inner.decode(Uri(path: '/nope')), isNull);
+      expect(codec.decode(Uri(path: '/nope')), isNull);
+    });
+
+    test('round-trips the top route through the adapter', () {
+      const stack = [_Home(), _Detail('rt')];
+      final decoded = codec.decode(codec.encode(stack));
+      // Adapter collapses to depth-1, keeping the top route.
+      expect(decoded, const [_Detail('rt')]);
+    });
+  });
+}

--- a/packages/kaisel_core/test/kaisel_stack_codec_test.dart
+++ b/packages/kaisel_core/test/kaisel_stack_codec_test.dart
@@ -1,8 +1,6 @@
 import 'package:kaisel_core/kaisel_core.dart';
 import 'package:test/test.dart';
 
-// Route fixtures — a small sealed hierarchy.
-
 sealed class _R extends KaiselRoute {
   const _R();
 }
@@ -18,9 +16,6 @@ final class _Detail extends _R {
   List<Object?> get props => [id];
 }
 
-// A concrete multi-frame stack codec.
-//   /      ⇄ [_Home]
-//   /d/42  ⇄ [_Home, _Detail('42')]
 class _StackCodec implements KaiselStackCodec<_R> {
   const _StackCodec();
 
@@ -38,9 +33,6 @@ class _StackCodec implements KaiselStackCodec<_R> {
   };
 }
 
-// A single-route codec, to be wrapped by KaiselSingleStackCodec.
-//   _Home()      ⇄ /
-//   _Detail(id)  ⇄ /d/<id>
 class _SingleCodec implements KaiselCodec<_R> {
   const _SingleCodec();
 
@@ -70,7 +62,6 @@ void main() {
     test('round-trips a deep-linked multi-frame stack', () {
       const stack = [_Home(), _Detail('42')];
       final encoded = codec.encode(stack);
-      // encode targets the top of the stack.
       expect(encoded.path, '/d/42');
       // decode restores the implicit parent frame too.
       expect(codec.decode(encoded), stack);
@@ -94,7 +85,6 @@ void main() {
 
     test('encode delegates to inner codec on the top of the stack', () {
       const stack = [_Home(), _Detail('x')];
-      // Should encode the TOP route, not the bottom.
       expect(codec.encode(stack), inner.encode(const _Detail('x')));
       expect(codec.encode(stack).path, '/d/x');
     });
@@ -110,7 +100,6 @@ void main() {
     });
 
     test('decode returns null when the inner codec returns null', () {
-      // Sanity: inner returns null for this URI.
       expect(inner.decode(Uri(path: '/nope')), isNull);
       expect(codec.decode(Uri(path: '/nope')), isNull);
     });

--- a/packages/kaisel_lint/test/rules_test.dart
+++ b/packages/kaisel_lint/test/rules_test.dart
@@ -428,8 +428,6 @@ final guard = (List<KaiselRoute> current, List<KaiselRoute> proposed) {
   }
 
   Future<void> test_fires_whenIfElseBothReturnProposed() async {
-    // Both arms of an if/else pass the proposed stack through unchanged, so the
-    // guard is still a no-op — the walker must descend into the else branch too.
     await assertDiagnostics(
       r'''
 import 'package:kaisel/kaisel.dart';

--- a/packages/kaisel_lint/test/rules_test.dart
+++ b/packages/kaisel_lint/test/rules_test.dart
@@ -427,6 +427,25 @@ final guard = (List<KaiselRoute> current, List<KaiselRoute> proposed) {
     );
   }
 
+  Future<void> test_fires_whenIfElseBothReturnProposed() async {
+    // Both arms of an if/else pass the proposed stack through unchanged, so the
+    // guard is still a no-op — the walker must descend into the else branch too.
+    await assertDiagnostics(
+      r'''
+import 'package:kaisel/kaisel.dart';
+
+final guard = (List<KaiselRoute> current, List<KaiselRoute> proposed) {
+  if (current.isEmpty) {
+    return proposed;
+  } else {
+    return proposed;
+  }
+};
+''',
+      [lint(52, 141)],
+    );
+  }
+
   Future<void> test_noFire_whenABranchRedirects() async {
     await assertNoDiagnostics(r'''
 import 'package:kaisel/kaisel.dart';


### PR DESCRIPTION
Each test exercises real, observable behaviour:

- Module mount lifecycle: back inside a module pops its own stack first; swapping the mounted module rewires to the new router; the mount rebuilds when its router pushes; restoreFromConfig replays a captured stack (and a foreign config is a no-op).
- KaiselListenableBuilder: rewires when the router prop changes (the old router stops driving rebuilds, the new one starts); asListenable() equality reflects the underlying router.
- KaiselPageScope.of returns the enclosing scope and asserts when there is none.
- A branch inner-navigator pageWrapper runs for the initial and pushed pages, including the adaptive-branch path.
- The delegate throws the documented error when a flow is active with no modalBuilder; back inside a flow pops its sub-stack then dismisses at root; an adaptive main delegate renders a flow as a standalone page.
- adaptiveEntryIdFromPageKey handles each key type; KaiselRouteInformationParser exposes its codec and fallback.

kaisel_core was largely exercised only through the kaisel (Flutter) package, so its own Flutter-free suite left whole files untested. Add pure-Dart tests:

- Stack codecs: a concrete KaiselStackCodec round-trips; KaiselSingleStackCodec encodes the top route and decodes to a depth-1 stack (and the null paths).
- Module codecs: ModuleStackCodec encode/decode + the untyped encodeAny/decodeAny bridge; ConfigCodecWithModules composes a host codec with a mounted module — module-top URLs, prefix-only fallback when no nested state is registered, host delegation for plain tops, and the no-match null path.
- Config value types: KaiselConfig.stackOnly; KaiselShellConfig / KaiselModuleConfig value equality; StackToConfigCodec delegation.
- Notifier: dispose guards (addListener / notifyListeners throw after dispose, removeListener is a safe no-op) and snapshot-iteration safety during dispatch.
- Router: onPageRemoved (match / unknown-id no-op / refuses to empty), applyFromInformation, and the entries view.

Test-only — no library changes.