### PR TITLE
feat(navigator): accept + expose navigatorKey on KaiselRouterConfig and KaiselRouterDelegate

### DIFF
--- a/packages/kaisel/CHANGELOG.md
+++ b/packages/kaisel/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.17.0
 
 ### Added
 

--- a/packages/kaisel/CHANGELOG.md
+++ b/packages/kaisel/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- **`navigatorKey`** on `KaiselRouterConfig` / `KaiselRouterDelegate` — pass a
+  `GlobalKey<NavigatorState>` for the main navigator (e.g. to hand to a
+  third-party SDK), or read the auto-created one via `config.navigatorKey` /
+  `config.navigator` for raw `NavigatorState` access. For context-free
+  *navigation*, the typed `router` stays the idiomatic handle.
+
 ## 0.16.0
 
 ### Added

--- a/packages/kaisel/README.md
+++ b/packages/kaisel/README.md
@@ -101,6 +101,8 @@ Add a variant and the switch fails to compile until you handle it. That's the en
 
 `_config.router` is the underlying `KaiselRouter<AppRoute>` for imperative navigation outside the tree; pass `codec:` to make the app URL-addressable ([§6](#6-urls-optional)). For full control you can still construct the `KaiselRouterDelegate` and parser yourself — `KaiselRouterConfig` is the convenience layer over them.
 
+Need a raw `GlobalKey<NavigatorState>` (for a third-party SDK, or `Navigator.of`-style overlays without a `BuildContext`)? Pass `navigatorKey:` to the config, or read the auto-created one via `_config.navigatorKey` / `_config.navigator`. For *navigation* itself, prefer `_config.router` — it's the context-free handle.
+
 ### 3. Guards
 
 Guards are `FutureOr<List<R>> Function(current, proposed)`. They run in order, each receiving the previous's output:

--- a/packages/kaisel/lib/src/kaisel_router_config.dart
+++ b/packages/kaisel/lib/src/kaisel_router_config.dart
@@ -59,6 +59,7 @@ class KaiselRouterConfig<R extends KaiselRoute>
     KaiselPageWrapper<R>? pageWrapper,
     KaiselModalBuilder? modalBuilder,
     KaiselObserversBuilder? observers,
+    GlobalKey<NavigatorState>? navigatorKey,
     KaiselConfigCodec<R>? codec,
     List<R>? fallback,
   }) {
@@ -71,6 +72,7 @@ class KaiselRouterConfig<R extends KaiselRoute>
         pageWrapper: pageWrapper,
         modalBuilder: modalBuilder,
         observers: observers,
+        navigatorKey: navigatorKey,
         codec: codec,
       ),
       codec: codec,
@@ -88,6 +90,7 @@ class KaiselRouterConfig<R extends KaiselRoute>
     KaiselPageWrapper<R>? pageWrapper,
     KaiselModalBuilder? modalBuilder,
     KaiselObserversBuilder? observers,
+    GlobalKey<NavigatorState>? navigatorKey,
     KaiselConfigCodec<R>? codec,
     List<R>? fallback,
   }) {
@@ -100,6 +103,7 @@ class KaiselRouterConfig<R extends KaiselRoute>
         pageWrapper: pageWrapper,
         modalBuilder: modalBuilder,
         observers: observers,
+        navigatorKey: navigatorKey,
         codec: codec,
       ),
       codec: codec,
@@ -139,6 +143,14 @@ class KaiselRouterConfig<R extends KaiselRoute>
 
   /// The bundled router, for imperative navigation outside the widget tree.
   final KaiselRouter<R> router;
+
+  /// The main [Navigator]'s key, for raw [NavigatorState] access (e.g. handing
+  /// it to a third-party SDK). Pass one in via `navigatorKey:`, or read the
+  /// auto-created one here. For navigation, prefer [router].
+  GlobalKey<NavigatorState> get navigatorKey => _delegate.navigatorKey;
+
+  /// The main [Navigator]'s current state, once mounted, or null before it is.
+  NavigatorState? get navigator => _delegate.navigatorKey.currentState;
 
   final KaiselRouterDelegate<R> _delegate;
   final RouteInformationProvider? _provider;

--- a/packages/kaisel/lib/src/kaisel_router_delegate.dart
+++ b/packages/kaisel/lib/src/kaisel_router_delegate.dart
@@ -113,9 +113,11 @@ class KaiselRouterDelegate<R extends KaiselRoute>
     this.pageWrapper,
     this.modalBuilder,
     this.observers,
+    GlobalKey<NavigatorState>? navigatorKey,
     KaiselConfigCodec<R>? codec,
   }) : _builder = builder,
        _adaptiveBuilder = null,
+       navigatorKey = navigatorKey ?? GlobalKey<NavigatorState>(),
        _codec = codec {
     router.addListener(_safeNotifyListeners);
     _registerWithInspector();
@@ -162,9 +164,11 @@ class KaiselRouterDelegate<R extends KaiselRoute>
     this.pageWrapper,
     this.modalBuilder,
     this.observers,
+    GlobalKey<NavigatorState>? navigatorKey,
     KaiselConfigCodec<R>? codec,
   }) : _builder = null,
        _adaptiveBuilder = builder,
+       navigatorKey = navigatorKey ?? GlobalKey<NavigatorState>(),
        _codec = codec {
     router.addListener(_safeNotifyListeners);
     _registerWithInspector();
@@ -205,8 +209,12 @@ class KaiselRouterDelegate<R extends KaiselRoute>
   late final List<NavigatorObserver> _mainObservers =
       observers?.call() ?? const <NavigatorObserver>[];
 
+  /// Key for the main [Navigator]. Pass one to reach the navigator imperatively
+  /// (e.g. a third-party SDK that wants a `GlobalKey<NavigatorState>`); defaults
+  /// to a freshly created key. For context-free *navigation*, prefer the typed
+  /// `router` — the key is for raw `NavigatorState` access.
   @override
-  final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+  final GlobalKey<NavigatorState> navigatorKey;
 
   /// Stable [GlobalKey]s for each active modal flow's inner Navigator.
   /// Indexed parallel to `router.activeFlows`. Grown lazily in [build]

--- a/packages/kaisel/pubspec.yaml
+++ b/packages/kaisel/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kaisel
 description: A Dart 3-native Flutter router built on sealed routes, pattern matching, and a stack-as-state model. No string paths, no codegen.
-version: 0.16.0
+version: 0.17.0
 repository: https://github.com/Mastersam07/kaisel
 homepage: https://github.com/Mastersam07/kaisel
 issue_tracker: https://github.com/Mastersam07/kaisel/issues

--- a/packages/kaisel/test/kaisel_navigator_key_test.dart
+++ b/packages/kaisel/test/kaisel_navigator_key_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kaisel/kaisel.dart';
+
+sealed class _R extends KaiselRoute {
+  const _R();
+}
+
+final class _Home extends _R {
+  const _Home();
+}
+
+void main() {
+  testWidgets(
+    'a passed navigatorKey drives the main navigator and is exposed',
+    (tester) async {
+      final key = GlobalKey<NavigatorState>();
+      final config = KaiselRouterConfig<_R>(
+        initial: const _Home(),
+        navigatorKey: key,
+        builder: (context, route) =>
+            const Scaffold(body: Center(child: Text('home'))),
+      );
+      addTearDown(config.dispose);
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: config));
+
+      expect(config.navigatorKey, same(key));
+      expect(key.currentState, isNotNull);
+      expect(config.navigator, same(key.currentState));
+    },
+  );
+
+  testWidgets(
+    'a navigatorKey is auto-created and exposed when none is passed',
+    (tester) async {
+      final config = KaiselRouterConfig<_R>(
+        initial: const _Home(),
+        builder: (context, route) =>
+            const Scaffold(body: Center(child: Text('home'))),
+      );
+      addTearDown(config.dispose);
+
+      await tester.pumpWidget(MaterialApp.router(routerConfig: config));
+
+      expect(config.navigatorKey, isNotNull);
+      expect(config.navigator, isNotNull);
+      expect(config.navigator, same(config.navigatorKey.currentState));
+    },
+  );
+}

--- a/skills/kaisel/SKILL.md
+++ b/skills/kaisel/SKILL.md
@@ -156,6 +156,11 @@ for you — the app is URL-addressable. The bundled router is reachable as
 outside the widget tree. Call `_config.dispose()` only when a `State`
 owns its lifecycle; a top-level `final` lives for the whole app.
 
+For a raw `GlobalKey<NavigatorState>` (a third-party SDK, or `Navigator.of`
+overlays without a `BuildContext`), pass `navigatorKey:` to the config or read
+`_config.navigatorKey` / `_config.navigator`. For navigation, prefer
+`_config.router` — the key is for raw navigator access only.
+
 **Navigator observers.** Pass `observers: () => [MyAnalyticsObserver()]` to
 attach `NavigatorObserver`s (analytics, Sentry, `RouteObserver`). It's a
 **builder**, not a list: a `NavigatorObserver` belongs to a single


### PR DESCRIPTION
Pass a GlobalKey<NavigatorState> for the main navigator, or read the auto-created one via config.navigatorKey / config.navigator for raw NavigatorState access.