### PR TITLE
fix: cap analysis_server_plugin below 0.3.16 so lints load on current sdks

### DIFF
--- a/packages/kaisel_lint/example/pubspec.lock
+++ b/packages/kaisel_lint/example/pubspec.lock
@@ -153,14 +153,14 @@ packages:
       path: "../../kaisel"
       relative: true
     source: path
-    version: "0.20.0"
+    version: "1.0.0-dev.3"
   kaisel_core:
     dependency: "direct overridden"
     description:
       path: "../../kaisel_core"
       relative: true
     source: path
-    version: "0.18.0"
+    version: "0.22.0"
   kaisel_lint:
     dependency: "direct dev"
     description:
@@ -217,13 +217,13 @@ packages:
     source: hosted
     version: "0.13.0"
   meta:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   package_config:
     dependency: transitive
     description:
@@ -333,6 +333,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   yaml:
     dependency: transitive
     description:

--- a/packages/kaisel_lint/example/pubspec.yaml
+++ b/packages/kaisel_lint/example/pubspec.yaml
@@ -24,5 +24,6 @@ dev_dependencies:
     path: ../
 
 dependency_overrides:
+  meta: ^1.18.3
   kaisel_core:
     path: ../../kaisel_core

--- a/packages/kaisel_lint/pubspec.lock
+++ b/packages/kaisel_lint/pubspec.lock
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: c82594181e3312f3d0695fc95aaaf7758d75b8d4ae2bbecf223b9fd5109a059d
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.3"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -333,26 +333,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: ca578dc12bb8b2f40b67b7d3bd2fac4f31c01a6ff7130a14e2597b919934507f
+      sha256: "0d5ba5602ec3baa28c8ce365e1efc5575969c765f45c554a3e167dc7945b9c30"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.1"
+    version: "1.31.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
+      sha256: "475610b2aa23c19687cce2961e44b0cc57cafe220f67c2b80201231b2a07fbe7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.12"
+    version: "0.7.13"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: d2e98ec12998368dc59ddd47ab709f2cd55acd6b66dc7db764455a44082f4bc5
+      sha256: a39c204a4fc7a7ccb04a2b985e359fda3cc37e45e0b8ac61c3fb1a05aa832132
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.18"
+    version: "0.6.19"
   test_reflective_loader:
     dependency: "direct dev"
     description:

--- a/packages/kaisel_lint/pubspec.yaml
+++ b/packages/kaisel_lint/pubspec.yaml
@@ -10,7 +10,10 @@ environment:
 dependencies:
   analyzer: ">=13.0.0 <14.0.0"
   analyzer_plugin: ">=0.14.9 <0.15.0"
-  analysis_server_plugin: ">=0.3.15 <0.4.0"
+  # <0.3.16: the last version speaking the legacy plugin dialect
+  # (analysis.setContextRoots) that current stable SDKs send. Lift when the SDK
+  # server sends analysis.setAnalysisRoots.
+  analysis_server_plugin: ">=0.3.15 <0.3.16"
 
 dev_dependencies:
   analyzer_testing: ">=0.2.6 <0.3.0"


### PR DESCRIPTION
0.3.16 dropped the legacy analysis.setContextRoots handler that current stable SDK analysis servers still send, so plugins built against newer versions load, pass the version check, then reject the request and sit idle — zero diagnostics, no visible error. 0.3.15 is the last version speaking the server's dialect; lift the cap when the SDK server moves to analysis.setAnalysisRoots.