### PR TITLE
chore: tree-shake icons and prune unused engine files from the devtools extension

### DIFF
--- a/packages/kaisel/.pubignore
+++ b/packages/kaisel/.pubignore
@@ -1,16 +1,13 @@
-# Controls which files `dart pub publish` includes. Pub honours .gitignore;
-# entries here adjust that for publishing (excludes, and `!` re-includes).
-
-# Dev-only test optimizer (see tool/test_optimizer.dart).
-tool/
-ROADMAP.md
-
-# The built DevTools extension is gitignored (**/build/) so the generated assets
-# stay out of git history — but it must ship inside the published package or
-# DevTools has no panel to load. Re-include it for publish only; run
-# `dart run devtools_extensions build_and_copy
-# --source=packages/kaisel_devtools --dest=packages/kaisel/extension/devtools`
-# before `pub publish` so the build is present and current.
+# Ship the DevTools extension build (gitignored by the repo-wide **/build/
+# rule) — pub publishes only unignored files, so without these negations the
+# extension would be missing from the archive.
 !extension/devtools/build/
 !extension/devtools/build/**
 doc/design/
+# Never ship artifacts the extension doesn't load at runtime: CanvasKit comes
+# from Google's CDN (see flutter_bootstrap.js), so the local engine variants
+# and debug symbols are dead weight; NOTICES is only fetched by a LicensePage
+# the extension doesn't have. release.sh also prunes these after
+# build_and_copy — this is the backstop for manual rebuilds.
+extension/devtools/build/canvaskit/
+extension/devtools/build/assets/NOTICES

--- a/packages/kaisel/CHANGELOG.md
+++ b/packages/kaisel/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.0-dev.5
+
+### Changed
+
+- **Published archive slimmed from 15 MB to 1 MB.** The bundled DevTools
+  extension build now tree-shakes icons (MaterialIcons 1.6 MB → 9 KB, verified
+  safe at compile time) and no longer ships the CanvasKit engine variants and
+  debug symbols it never loads — the extension fetches CanvasKit from Google's
+  CDN, as it already did. No runtime behaviour change.
+
 ## 1.0.0-dev.4
 
 ### Added

--- a/packages/kaisel/README.md
+++ b/packages/kaisel/README.md
@@ -777,7 +777,7 @@ npx skills add Mastersam07/kaisel
 
 ## Status
 
-**v1.0.0-dev.3, a 1.0 pre-release.** The core surface is in place: routes, guards, shells (homogeneous and per-branch typed), typed main-stack results (`pushForResult<T>`), modal flows (rendered as routes on the main navigator, so dialogs and observers compose with them), URL-addressable shell and module state, composable modules with URL composition, adaptive layouts at every level, route-pair-aware transitions, `KaiselPageScope`, navigator observers, a DevTools extension, state restoration, and opt-in Android predictive-back transitions. The public API is shaped for stability but not yet frozen — expect occasional breaking changes before 1.0, each with a migration note in the [changelog](CHANGELOG.md).
+**v1.0.0-dev.5, a 1.0 pre-release.** The core surface is in place: routes, guards, shells (homogeneous and per-branch typed), typed main-stack results (`pushForResult<T>`), modal flows (rendered as routes on the main navigator, so dialogs and observers compose with them), URL-addressable shell and module state, composable modules with URL composition, adaptive layouts at every level, route-pair-aware transitions, `KaiselPageScope`, navigator observers, a DevTools extension, state restoration, and opt-in Android predictive-back transitions. The public API is shaped for stability but not yet frozen — expect occasional breaking changes before 1.0, each with a migration note in the [changelog](CHANGELOG.md).
 
 ## Example
 

--- a/packages/kaisel/pubspec.yaml
+++ b/packages/kaisel/pubspec.yaml
@@ -1,6 +1,6 @@
 name: kaisel
 description: A Dart 3-native Flutter router built on sealed routes, pattern matching, and a stack-as-state model. No string paths, no codegen.
-version: 1.0.0-dev.4
+version: 1.0.0-dev.5
 repository: https://github.com/Mastersam07/kaisel
 homepage: https://github.com/Mastersam07/kaisel
 issue_tracker: https://github.com/Mastersam07/kaisel/issues

--- a/packages/kaisel_devtools/tool/release.sh
+++ b/packages/kaisel_devtools/tool/release.sh
@@ -14,8 +14,9 @@
 #   e.g. packages/kaisel_devtools/tool/release.sh 0.3.0
 #
 # Afterwards: update packages/kaisel_devtools/CHANGELOG.md and commit the
-# pubspec and config.yaml. The build/ output is gitignored — it is regenerated
-# here and ships when the kaisel package is published.
+# pubspec and config.yaml. The build/ output stays gitignored; kaisel's
+# .pubignore re-includes it at publish time (and keeps the pruned artifacts
+# excluded as a backstop).
 set -euo pipefail
 
 version="${1:-}"
@@ -41,13 +42,28 @@ echo "Setting kaisel_devtools and the extension config to ${version}..."
 set_version "$pubspec"
 set_version "$config"
 
-echo "Building and copying the DevTools extension…"
-( cd "$root" && dart run devtools_extensions build_and_copy \
-    --source=packages/kaisel_devtools \
-    --dest=packages/kaisel/extension/devtools )
+echo "Building the DevTools extension…"
+# Same flags devtools_extensions' build_and_copy uses, minus
+# --no-tree-shake-icons: the extension only uses const icons, so tree-shaking
+# is verified safe at compile time and cuts MaterialIcons from 1.6 MB to 9 KB.
+( cd "$root/packages/kaisel_devtools" && flutter build web \
+    --pwa-strategy=offline-first --release )
+
+echo "Copying into packages/kaisel/extension/devtools/build…"
+rm -rf "$root/packages/kaisel/extension/devtools/build"
+cp -R "$root/packages/kaisel_devtools/build/web" \
+      "$root/packages/kaisel/extension/devtools/build"
+
+# Prune artifacts the extension never loads at runtime: CanvasKit comes from
+# Google's CDN (flutter_bootstrap.js), so the local engine variants and debug
+# symbols are dead weight (~29 MB), and NOTICES is only fetched by a
+# LicensePage the extension doesn't have.
+echo "Pruning unused build artifacts…"
+rm -rf "$root/packages/kaisel/extension/devtools/build/canvaskit"
+rm -f "$root/packages/kaisel/extension/devtools/build/assets/NOTICES"
 
 echo
 echo "Done. Remaining manual steps:"
 echo "  - add a $version entry to packages/kaisel_devtools/CHANGELOG.md"
-echo "  - commit pubspec.yaml and config.yaml (build/ is gitignored; it is"
-echo "    regenerated here and ships when the kaisel package is published)"
+echo "  - commit pubspec.yaml and config.yaml (build/ stays gitignored; it"
+echo "    ships via kaisel's .pubignore negation when kaisel is published)"


### PR DESCRIPTION
The extension build loads **CanvasKit** from **Google's CDN**, so the bundled engine variants and debug symbols (**~29 MB**) were never fetched; **NOTICES** only serves a LicensePage the extension doesn't have. release.sh now builds with icon tree-shaking (compile-time verified; **MaterialIcons 1.6 MB → 9 KB**) and prunes after copying, with .pubignore as the backstop. 

Published archive: **_15 MB → 1 MB_**.
