### PR TITLE
fix: defer example log observer with a microtask

### DIFF
--- a/packages/kaisel/example/lib/main_results_and_flows.dart
+++ b/packages/kaisel/example/lib/main_results_and_flows.dart
@@ -23,6 +23,8 @@
 //    instantly. The custom page forwards `name`/`arguments` so it stays
 //    observable.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:kaisel/kaisel.dart';
 
@@ -59,7 +61,13 @@ class _LogObserver extends NavigatorObserver {
     if (route.settings.name case final name?) _add('← $name');
   }
 
-  void _add(String entry) => _log.value = [..._log.value, entry];
+  // A newly mounted navigator (a flow opening) dispatches its initial
+  // observer notifications during build; mutating a listenable bound to
+  // widgets there throws markNeedsBuild-during-build. A microtask can't
+  // run mid-build, so this defers exactly enough — and from a tap it
+  // still lands before the next frame.
+  void _add(String entry) =>
+      scheduleMicrotask(() => _log.value = [..._log.value, entry]);
 }
 
 class _HomeScreen extends StatefulWidget {

--- a/packages/kaisel/test/kaisel_observer_deferred_ui_test.dart
+++ b/packages/kaisel/test/kaisel_observer_deferred_ui_test.dart
@@ -1,0 +1,65 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:kaisel/kaisel.dart';
+
+// A flow's inner navigator mounts during build and dispatches its initial
+// observer notifications right there. This pins the pattern the docs
+// recommend for observers feeding widget-bound state (how-to/track-screens):
+// defer with a microtask, which can never run mid-build.
+
+sealed class _App extends KaiselRoute {
+  const _App();
+}
+
+final class _Home extends _App {
+  const _Home();
+}
+
+final class _Flow extends _App implements KaiselModalRoute<void> {
+  const _Flow();
+}
+
+final _log = ValueNotifier<List<String>>(const []);
+
+class _UiBoundObserver extends NavigatorObserver {
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    if (route.settings.name case final name?) _add('→ $name');
+  }
+
+  void _add(String entry) =>
+      scheduleMicrotask(() => _log.value = [..._log.value, entry]);
+}
+
+void main() {
+  testWidgets('deferred UI-bound observer survives a flow mounting', (
+    tester,
+  ) async {
+    _log.value = const [];
+    final router = KaiselRouter<_App>(initial: const _Home());
+    final delegate = KaiselRouterDelegate<_App>(
+      router: router,
+      observers: () => [_UiBoundObserver()],
+      builder: (context, route) => switch (route) {
+        _Home() => Scaffold(
+          body: ValueListenableBuilder<List<String>>(
+            valueListenable: _log,
+            builder: (context, entries, _) => Text('log:${entries.length}'),
+          ),
+        ),
+        _Flow() => const Text('flow-content'),
+      },
+      modalBuilder: (context, route, child) => Center(child: child),
+    );
+    await tester.pumpWidget(MaterialApp.router(routerDelegate: delegate));
+
+    unawaited(router.run<void>(const _Flow()));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('flow-content'), findsOneWidget);
+    expect(_log.value, contains('→ _Flow'));
+  });
+}

--- a/site/src/content/docs/how-to/track-screens.md
+++ b/site/src/content/docs/how-to/track-screens.md
@@ -55,6 +55,18 @@ KaiselRouterConfig<AppRoute>(
 
 - The `observers:` builder must return **new instances each call** — an
   observer belongs to exactly one navigator. Don't share one instance.
+- **Don't synchronously update widget-bound state from observer
+  callbacks.** A newly mounted navigator (a flow opening, a tab's first
+  build) dispatches its initial notifications *during build* — mutating a
+  `ValueNotifier` a `ValueListenableBuilder` watches will throw
+  markNeedsBuild-during-build. Analytics calls are fine (they're I/O);
+  for UI-bound state, defer with a microtask — it can never run mid-build,
+  and from a tap it still lands before the next frame renders:
+
+  ```dart
+  void _add(String entry) =>
+      scheduleMicrotask(() => _log.value = [..._log.value, entry]);
+  ```
 - Using a custom `pageWrapper`? Forward `name:` and `arguments:` on every
   page you return, or observers go blind — see
   [Transitions](/guides/transitions/).


### PR DESCRIPTION
A newly mounted navigator (the flow opening) dispatches its initial observer notifications during build; writing to a widget-bound ValueNotifier there throws markNeedsBuild-during-build. A microtask can't run mid-build and still lands before the next frame from a tap. Documents the pattern in the track-screens how-to and pins it with a widget test.

Fixes #57