### PR TITLE
feat: add set alias to KaiselNavigator

### DIFF
--- a/packages/kaisel_core/lib/kaisel_core.dart
+++ b/packages/kaisel_core/lib/kaisel_core.dart
@@ -27,6 +27,7 @@ export 'src/kaisel_router.dart'
     show
         KaiselActiveFlow,
         KaiselNavigator,
+        KaiselNavigatorSet,
         KaiselRouter,
         KaiselTransitionCallback;
 export 'src/kaisel_stack_codec.dart';

--- a/packages/kaisel_core/lib/src/kaisel_router.dart
+++ b/packages/kaisel_core/lib/src/kaisel_router.dart
@@ -110,6 +110,15 @@ abstract class KaiselNavigator implements KaiselListenable {
   bool get replacesHistoryEntry;
 }
 
+/// Stack-assignment operations for a type-erased [KaiselNavigator].
+extension KaiselNavigatorSet on KaiselNavigator {
+  /// Replace this navigator's stack with [stack].
+  ///
+  /// This is an assignment-oriented alias for [restoreStack]. Use
+  /// [restoreStack] when restoring previously captured navigation state.
+  Future<void> set(List<KaiselRoute> stack) => restoreStack(stack);
+}
+
 /// Identity-stable wrapper for a route on the stack.
 ///
 /// Two value-equal routes (e.g. `const Home()` pushed twice) still need

--- a/packages/kaisel_core/test/kaisel_config_test.dart
+++ b/packages/kaisel_core/test/kaisel_config_test.dart
@@ -335,4 +335,16 @@ void main() {
       expect(r.stack, const [_HomeRoot()]);
     });
   });
+
+  group('KaiselNavigator.set', () {
+    test('replaces the stack through the type-erased interface', () async {
+      final router = KaiselRouter<_Home>(initial: const _HomeRoot());
+      addTearDown(router.dispose);
+      final KaiselNavigator navigator = router;
+
+      await navigator.set(const [_HomeRoot(), _Product('a')]);
+
+      expect(router.stack, const [_HomeRoot(), _Product('a')]);
+    });
+  });
 }


### PR DESCRIPTION
Closes #73.

Adds `set(...)` as an assignment-oriented alias for `restoreStack(...)` on
the type-erased `KaiselNavigator` API.

The alias delegates to the existing restoration path, preserving route type
validation, guards, and history behavior. The strongly typed
`KaiselRouter<R>.set(List<R>)` API remains unchanged.

A regression test covers assigning a stack through a value statically typed
as `KaiselNavigator`.

Testing:
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze packages/kaisel_core packages/kaisel packages/kaisel_devtools packages/kaisel_lint/lib packages/kaisel_lint/test`
- `dart test` in `packages/kaisel_core`
- `flutter test --no-pub --coverage test/.test_optimizer.dart` in `packages/kaisel`
- `flutter test --no-pub --coverage test/.test_optimizer.dart` in `packages/kaisel_devtools`
- `dart test --coverage=coverage` in `packages/kaisel_lint`
